### PR TITLE
Have HttpClient ignore cookies

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -20,6 +20,7 @@ import org.apache.http.*;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.AbortableHttpRequest;
 import org.apache.http.client.params.ClientPNames;
+import org.apache.http.client.params.CookiePolicy;
 import org.apache.http.client.utils.URIUtils;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -37,6 +38,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;


### PR DESCRIPTION
This is my first pull request, so I am sorry if I'm not going about this the right way.

It was noticed that while running under Tomcat 7, cookies that were set from previous requests were being added to subsequent requests, despite those requests never containing a Cookie header.

I'm certain that the expectation is for the proxy to be completely transparent, and it would seem Apache's HttpClient does some behind the scenes work with regards to cookies.

This change sets the cookie police to IGNORE_COOKIES, preventing any automated cooking handling, while still allowing manual entry of the Cookie/Set-Cookie headers.

This has fixed our issues, no more unexpected cookies are being set.
