### PR TITLE
Prevent IllegalStateException during redirect

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -240,7 +240,10 @@ public class ProxyServlet extends HttpServlet {
     } finally {
       // make sure the entire entity was consumed, so the connection is released
       consumeQuietly(proxyResponse.getEntity());
-      closeQuietly(servletResponse.getOutputStream());
+      if (servletResponse.isCommitted() == false) {
+        ServletOutputStream outputStream = servletResponse.getOutputStream();
+        closeQuietly(outputStream);
+      }
     }
   }
 


### PR DESCRIPTION
On Glassfish 3.1.2.2 in case of an redirect you get a 
java.lang.IllegalStateException: PWC3990: getWriter() has already been called for this response
    at org.apache.catalina.connector.Response.getOutputStream(Response.java:674)
    at org.apache.catalina.connector.ResponseFacade.getOutputStream(ResponseFacade.java:206)

First check if response is already commited before accessing the stream.
