### PR TITLE
Split the proxy behavior from the encapsulation in a servlet

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/Logger.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/Logger.java
@@ -1,0 +1,6 @@
+package org.mitre.dsmiley.httpproxy;
+
+public interface Logger {
+  void logMessage(String s, Exception e);
+  void logMessage(String s);
+}

--- a/src/main/java/org/mitre/dsmiley/httpproxy/Proxy.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/Proxy.java
@@ -1,0 +1,512 @@
+package org.mitre.dsmiley.httpproxy;
+
+import org.apache.http.*;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.AbortableHttpRequest;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.message.HeaderGroup;
+import org.apache.http.params.HttpParams;
+import org.apache.http.util.EntityUtils;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.util.BitSet;
+import java.util.Enumeration;
+import java.util.Formatter;
+import java.util.List;
+
+public class Proxy {
+  private HttpClient proxyClient;
+  private Logger logger;
+  private String cookieNamePrefix;
+  /* MISC */
+
+  protected boolean doForwardIP = true;
+  /** User agents shouldn't send the url fragment but what if it does? */
+  protected boolean doSendUrlFragment = true;
+
+  private QueryStringRewriter qsRewriter;
+
+  public Proxy() {
+    qsRewriter = new QueryStringRewriter() {
+      @Override
+      public String rewriteQueryStringFromRequest(HttpServletRequest servletRequest, String queryString) {
+        return defaultRrewriteQueryStringFromRequest(servletRequest, queryString);
+      }
+    };
+  }
+
+  public void destroy() {
+    //As of HttpComponents v4.3, clients implement closeable
+    if (proxyClient instanceof Closeable) {//TODO AutoCloseable in Java 1.6
+      try {
+        ((Closeable) proxyClient).close();
+      } catch (IOException e) {
+        log("While destroying servlet, shutting down HttpClient: "+e, e);
+      }
+    } else {
+      //Older releases require we do this:
+      if (proxyClient != null)
+        proxyClient.getConnectionManager().shutdown();
+    }
+  }
+
+  private void log(String s, Exception e) {
+    if (logger!=null) logger.logMessage(s, e);
+  }
+  private void log(String s) {
+    if (logger!=null) logger.logMessage(s);
+  }
+
+  public HttpResponse execute(HttpHost targetHost, HttpRequest proxyRequest) throws IOException {
+    return proxyClient.execute(targetHost, proxyRequest);
+  }
+
+  /** Called from {@link #init(javax.servlet.ServletConfig)}. HttpClient offers many opportunities
+   * for customization. By default,
+   * <a href="http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/SystemDefaultHttpClient.html">
+   *   SystemDefaultHttpClient</a> is used if available, otherwise it falls
+   * back to:
+   * <pre>new DefaultHttpClient(new ThreadSafeClientConnManager(),hcParams)</pre>
+   * SystemDefaultHttpClient uses PoolingClientConnectionManager. In any case, it should be thread-safe. */
+  @SuppressWarnings({"unchecked", "deprecation"})
+  protected HttpClient createHttpClient(HttpParams hcParams) {
+    try {
+      //as of HttpComponents v4.2, this class is better since it uses System
+      // Properties:
+      Class clientClazz = Class.forName("org.apache.http.impl.client.SystemDefaultHttpClient");
+      Constructor constructor = clientClazz.getConstructor(HttpParams.class);
+      return (HttpClient) constructor.newInstance(hcParams);
+    } catch (ClassNotFoundException e) {
+      //no problem; use v4.1 below
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    //Fallback on using older client:
+    return new DefaultHttpClient(new ThreadSafeClientConnManager(), hcParams);
+  }
+
+
+  public void buildProxyClient(HttpParams hcParams) {
+    proxyClient = createHttpClient(hcParams);
+  }
+
+  public void forward(HttpServletRequest servletRequest, HttpServletResponse servletResponse, String targetUri, HttpHost targetHost) throws ServletException, IOException {
+    // Make the Request
+    //note: we won't transfer the protocol version because I'm not sure it would truly be compatible
+    String method = servletRequest.getMethod();
+    String proxyRequestUri = rewriteUrlFromRequest(servletRequest, targetUri);
+    HttpRequest proxyRequest;
+    //spec: RFC 2616, sec 4.3: either of these two headers signal that there is a message body.
+    if (servletRequest.getHeader(HttpHeaders.CONTENT_LENGTH) != null ||
+            servletRequest.getHeader(HttpHeaders.TRANSFER_ENCODING) != null) {
+      HttpEntityEnclosingRequest eProxyRequest = new BasicHttpEntityEnclosingRequest(method, proxyRequestUri);
+      // Add the input entity (streamed)
+      //  note: we don't bother ensuring we close the servletInputStream since the container handles it
+      eProxyRequest.setEntity(new InputStreamEntity(servletRequest.getInputStream(), servletRequest.getContentLength()));
+      proxyRequest = eProxyRequest;
+    } else
+      proxyRequest = new BasicHttpRequest(method, proxyRequestUri);
+
+    copyRequestHeaders(servletRequest, proxyRequest, targetHost);
+
+    setXForwardedForHeader(servletRequest, proxyRequest);
+
+    HttpResponse proxyResponse = null;
+    try {
+      // Execute the request
+      if (logger!=null) {
+        log("proxy " + method + " uri: " + servletRequest.getRequestURI() + " -- " + proxyRequest.getRequestLine().getUri());
+      }
+      proxyResponse = execute(targetHost, proxyRequest);
+
+      // Process the response
+      int statusCode = proxyResponse.getStatusLine().getStatusCode();
+
+      // copying response headers to make sure SESSIONID or other Cookie which comes from remote server
+      // will be saved in client when the proxied url was redirected to another one.
+      // see issue [#51](https://github.com/mitre/HTTP-Proxy-Servlet/issues/51)
+      copyResponseHeaders(proxyResponse, servletRequest, servletResponse);
+
+      if (doResponseRedirectOrNotModifiedLogic(servletRequest, servletResponse, proxyResponse, statusCode, targetUri)) {
+        //the response is already "committed" now without any body to send
+        return;
+      }
+
+      // Pass the response code. This method with the "reason phrase" is deprecated but it's the only way to pass the
+      //  reason along too.
+      //noinspection deprecation
+      servletResponse.setStatus(statusCode, proxyResponse.getStatusLine().getReasonPhrase());
+
+      // Send the content to the client
+      copyResponseEntity(proxyResponse, servletResponse);
+
+    } catch (Exception e) {
+      //abort request, according to best practice with HttpClient
+      if (proxyRequest instanceof AbortableHttpRequest) {
+        AbortableHttpRequest abortableHttpRequest = (AbortableHttpRequest) proxyRequest;
+        abortableHttpRequest.abort();
+      }
+      if (e instanceof RuntimeException)
+        throw (RuntimeException)e;
+      if (e instanceof ServletException)
+        throw (ServletException)e;
+      //noinspection ConstantConditions
+      if (e instanceof IOException)
+        throw (IOException) e;
+      throw new RuntimeException(e);
+
+    } finally {
+      // make sure the entire entity was consumed, so the connection is released
+      if (proxyResponse != null)
+        consumeQuietly(proxyResponse.getEntity());
+      //Note: Don't need to close servlet outputStream:
+      // http://stackoverflow.com/questions/1159168/should-one-call-close-on-httpservletresponse-getoutputstream-getwriter
+    }
+
+  }
+
+  protected boolean doResponseRedirectOrNotModifiedLogic(
+          HttpServletRequest servletRequest, HttpServletResponse servletResponse,
+          HttpResponse proxyResponse, int statusCode, String targetUri)
+          throws ServletException, IOException {
+    // Check if the proxy response is a redirect
+    // The following code is adapted from org.tigris.noodle.filters.CheckForRedirect
+    if (statusCode >= HttpServletResponse.SC_MULTIPLE_CHOICES /* 300 */
+            && statusCode < HttpServletResponse.SC_NOT_MODIFIED /* 304 */) {
+      Header locationHeader = proxyResponse.getLastHeader(HttpHeaders.LOCATION);
+      if (locationHeader == null) {
+        throw new ServletException("Received status code: " + statusCode
+                + " but no " + HttpHeaders.LOCATION + " header was found in the response");
+      }
+      // Modify the redirect to go to this proxy servlet rather that the proxied host
+      String locStr = rewriteUrlFromResponse(servletRequest, locationHeader.getValue(), targetUri);
+
+      servletResponse.sendRedirect(locStr);
+      return true;
+    }
+    // 304 needs special handling.  See:
+    // http://www.ics.uci.edu/pub/ietf/http/rfc1945.html#Code304
+    // We get a 304 whenever passed an 'If-Modified-Since'
+    // header and the data on disk has not changed; server
+    // responds w/ a 304 saying I'm not going to send the
+    // body because the file has not changed.
+    if (statusCode == HttpServletResponse.SC_NOT_MODIFIED) {
+      servletResponse.setIntHeader(HttpHeaders.CONTENT_LENGTH, 0);
+      servletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+      return true;
+    }
+    return false;
+  }
+
+  protected void closeQuietly(Closeable closeable) {
+    try {
+      closeable.close();
+    } catch (IOException e) {
+      log(e.getMessage(), e);
+    }
+  }
+
+  /** HttpClient v4.1 doesn't have the
+   * {@link org.apache.http.util.EntityUtils#consumeQuietly(org.apache.http.HttpEntity)} method. */
+  protected void consumeQuietly(HttpEntity entity) {
+    try {
+      EntityUtils.consume(entity);
+    } catch (IOException e) {//ignore
+      log(e.getMessage(), e);
+    }
+  }
+
+  /** Copy request headers from the servlet client to the proxy request. */
+  protected void copyRequestHeaders(HttpServletRequest servletRequest, HttpRequest proxyRequest, HttpHost targetHost) {
+    // Get an Enumeration of all of the header names sent by the client
+    Enumeration enumerationOfHeaderNames = servletRequest.getHeaderNames();
+    while (enumerationOfHeaderNames.hasMoreElements()) {
+      String headerName = (String) enumerationOfHeaderNames.nextElement();
+      //Instead the content-length is effectively set via InputStreamEntity
+      if (headerName.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH))
+        continue;
+      if (hopByHopHeaders.containsHeader(headerName))
+        continue;
+
+      Enumeration headers = servletRequest.getHeaders(headerName);
+      while (headers.hasMoreElements()) {//sometimes more than one value
+        String headerValue = (String) headers.nextElement();
+        // In case the proxy host is running multiple virtual servers,
+        // rewrite the Host header to ensure that we get content from
+        // the correct virtual server
+        if (headerName.equalsIgnoreCase(HttpHeaders.HOST)) {
+          HttpHost host = targetHost;
+          headerValue = host.getHostName();
+          if (host.getPort() != -1)
+            headerValue += ":"+host.getPort();
+        } else if (headerName.equalsIgnoreCase(org.apache.http.cookie.SM.COOKIE)) {
+          headerValue = getRealCookie(headerValue);
+        }
+        proxyRequest.addHeader(headerName, headerValue);
+      }
+    }
+  }
+
+  private void setXForwardedForHeader(HttpServletRequest servletRequest,
+                                      HttpRequest proxyRequest) {
+    String headerName = "X-Forwarded-For";
+    if (doForwardIP) {
+      String newHeader = servletRequest.getRemoteAddr();
+      String existingHeader = servletRequest.getHeader(headerName);
+      if (existingHeader != null) {
+        newHeader = existingHeader + ", " + newHeader;
+      }
+      proxyRequest.setHeader(headerName, newHeader);
+    }
+  }
+
+  /** Copy proxied response headers back to the servlet client. */
+  protected void copyResponseHeaders(HttpResponse proxyResponse, HttpServletRequest servletRequest,
+                                     HttpServletResponse servletResponse) {
+    for (Header header : proxyResponse.getAllHeaders()) {
+      if (hopByHopHeaders.containsHeader(header.getName()))
+        continue;
+      if (header.getName().equalsIgnoreCase(org.apache.http.cookie.SM.SET_COOKIE) ||
+              header.getName().equalsIgnoreCase(org.apache.http.cookie.SM.SET_COOKIE2)) {
+        copyProxyCookie(servletRequest, servletResponse, header);
+      } else {
+        servletResponse.addHeader(header.getName(), header.getValue());
+      }
+    }
+  }
+
+  /** Copy cookie from the proxy to the servlet client.
+   *  Replaces cookie path to local path and renames cookie to avoid collisions.
+   */
+  protected void copyProxyCookie(HttpServletRequest servletRequest,
+                                 HttpServletResponse servletResponse, Header header) {
+    List<HttpCookie> cookies = HttpCookie.parse(header.getValue());
+    String path = servletRequest.getContextPath(); // path starts with / or is empty string
+    path += servletRequest.getServletPath(); // servlet path starts with / or is empty string
+
+    for (HttpCookie cookie : cookies) {
+      //set cookie name prefixed w/ a proxy value so it won't collide w/ other cookies
+      String proxyCookieName = getCookieNamePrefix() + cookie.getName();
+      Cookie servletCookie = new Cookie(proxyCookieName, cookie.getValue());
+      servletCookie.setComment(cookie.getComment());
+      servletCookie.setMaxAge((int) cookie.getMaxAge());
+      servletCookie.setPath(path); //set to the path of the proxy servlet
+      // don't set cookie domain
+      servletCookie.setSecure(cookie.getSecure());
+      servletCookie.setVersion(cookie.getVersion());
+      servletResponse.addCookie(servletCookie);
+    }
+  }
+
+  /** Take any client cookies that were originally from the proxy and prepare them to send to the
+   * proxy.  This relies on cookie headers being set correctly according to RFC 6265 Sec 5.4.
+   * This also blocks any local cookies from being sent to the proxy.
+   */
+  protected String getRealCookie(String cookieValue) {
+    StringBuilder escapedCookie = new StringBuilder();
+    String cookies[] = cookieValue.split("; ");
+    for (String cookie : cookies) {
+      String cookieSplit[] = cookie.split("=");
+      if (cookieSplit.length == 2) {
+        String cookieName = cookieSplit[0];
+        if (cookieName.startsWith(getCookieNamePrefix())) {
+          cookieName = cookieName.substring(getCookieNamePrefix().length());
+          if (escapedCookie.length() > 0) {
+            escapedCookie.append("; ");
+          }
+          escapedCookie.append(cookieName).append("=").append(cookieSplit[1]);
+        }
+      }
+
+      cookieValue = escapedCookie.toString();
+    }
+    return cookieValue;
+  }
+
+
+  /** Copy response body data (the entity) from the proxy to the servlet client. */
+  protected void copyResponseEntity(HttpResponse proxyResponse, HttpServletResponse servletResponse) throws IOException {
+    HttpEntity entity = proxyResponse.getEntity();
+    if (entity != null) {
+      OutputStream servletOutputStream = servletResponse.getOutputStream();
+      entity.writeTo(servletOutputStream);
+    }
+  }
+
+  /** Reads the request URI from {@code servletRequest} and rewrites it, considering targetUri.
+   * It's used to make the new request.
+   */
+  protected String rewriteUrlFromRequest(HttpServletRequest servletRequest, String targetUri) {
+    StringBuilder uri = new StringBuilder(500);
+    uri.append(targetUri);
+    // Handle the path given to the servlet
+    if (servletRequest.getPathInfo() != null) {//ex: /my/path.html
+      uri.append(encodeUriQuery(servletRequest.getPathInfo()));
+    }
+    // Handle the query string & fragment
+    String queryString = servletRequest.getQueryString();//ex:(following '?'): name=value&foo=bar#fragment
+    String fragment = null;
+    //split off fragment from queryString, updating queryString if found
+    if (queryString != null) {
+      int fragIdx = queryString.indexOf('#');
+      if (fragIdx >= 0) {
+        fragment = queryString.substring(fragIdx + 1);
+        queryString = queryString.substring(0,fragIdx);
+      }
+    }
+
+    queryString = qsRewriter.rewriteQueryStringFromRequest(servletRequest, queryString);
+    if (queryString != null && queryString.length() > 0) {
+      uri.append('?');
+      uri.append(encodeUriQuery(queryString));
+    }
+
+    if (doSendUrlFragment && fragment != null) {
+      uri.append('#');
+      uri.append(encodeUriQuery(fragment));
+    }
+    return uri.toString();
+  }
+
+  protected String defaultRrewriteQueryStringFromRequest(HttpServletRequest servletRequest, String queryString) {
+    return queryString;
+  }
+
+  /** For a redirect response from the target server, this translates {@code theUrl} to redirect to
+   * and translates it to one the original client can use. */
+  protected String rewriteUrlFromResponse(HttpServletRequest servletRequest, String theUrl, final String targetUri) {
+    //TODO document example paths
+    if (theUrl.startsWith(targetUri)) {
+      String curUrl = servletRequest.getRequestURL().toString();//no query
+      String pathInfo = servletRequest.getPathInfo();
+      if (pathInfo != null) {
+        assert curUrl.endsWith(pathInfo);
+        curUrl = curUrl.substring(0,curUrl.length()-pathInfo.length());//take pathInfo off
+      }
+      theUrl = curUrl+theUrl.substring(targetUri.length());
+    }
+    return theUrl;
+  }
+
+
+  /**
+   * Encodes characters in the query or fragment part of the URI.
+   *
+   * <p>Unfortunately, an incoming URI sometimes has characters disallowed by the spec.  HttpClient
+   * insists that the outgoing proxied request has a valid URI because it uses Java's {@link URI}.
+   * To be more forgiving, we must escape the problematic characters.  See the URI class for the
+   * spec.
+   *
+   * @param in example: name=value&foo=bar#fragment
+   */
+  protected static CharSequence encodeUriQuery(CharSequence in) {
+    //Note that I can't simply use URI.java to encode because it will escape pre-existing escaped things.
+    StringBuilder outBuf = null;
+    Formatter formatter = null;
+    for(int i = 0; i < in.length(); i++) {
+      char c = in.charAt(i);
+      boolean escape = true;
+      if (c < 128) {
+        if (asciiQueryChars.get((int)c)) {
+          escape = false;
+        }
+      } else if (!Character.isISOControl(c) && !Character.isSpaceChar(c)) {//not-ascii
+        escape = false;
+      }
+      if (!escape) {
+        if (outBuf != null)
+          outBuf.append(c);
+      } else {
+        //escape
+        if (outBuf == null) {
+          outBuf = new StringBuilder(in.length() + 5*3);
+          outBuf.append(in,0,i);
+          formatter = new Formatter(outBuf);
+        }
+        //leading %, 0 padded, width 2, capital hex
+        formatter.format("%%%02X",(int)c);//TODO
+      }
+    }
+    return outBuf != null ? outBuf : in;
+  }
+
+  protected static final BitSet asciiQueryChars;
+  static {
+    char[] c_unreserved = "_-!.~'()*".toCharArray();//plus alphanum
+    char[] c_punct = ",;:$&+=".toCharArray();
+    char[] c_reserved = "?/[]@".toCharArray();//plus punct
+
+    asciiQueryChars = new BitSet(128);
+    for(char c = 'a'; c <= 'z'; c++) asciiQueryChars.set((int)c);
+    for(char c = 'A'; c <= 'Z'; c++) asciiQueryChars.set((int)c);
+    for(char c = '0'; c <= '9'; c++) asciiQueryChars.set((int)c);
+    for(char c : c_unreserved) asciiQueryChars.set((int)c);
+    for(char c : c_punct) asciiQueryChars.set((int)c);
+    for(char c : c_reserved) asciiQueryChars.set((int)c);
+
+    asciiQueryChars.set((int)'%');//leave existing percent escapes in place
+  }
+
+  /** These are the "hop-by-hop" headers that should not be copied.
+   * http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+   * I use an HttpClient HeaderGroup class instead of Set<String> because this
+   * approach does case insensitive lookup faster.
+   */
+  protected static final HeaderGroup hopByHopHeaders;
+  static {
+    hopByHopHeaders = new HeaderGroup();
+    String[] headers = new String[] {
+            "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
+            "TE", "Trailers", "Transfer-Encoding", "Upgrade" };
+    for (String header : headers) {
+      hopByHopHeaders.addHeader(new BasicHeader(header, null));
+    }
+  }
+
+  public void defineQueryStringRewriter(QueryStringRewriter r) {
+    qsRewriter = r;
+  }
+
+  public HttpClient getProxyClient() {
+    return proxyClient;
+  }
+
+  public Logger getLogger() {
+    return logger;
+  }
+
+  public void setLogger(Logger logger) {
+    this.logger = logger;
+  }
+
+  public void setDoSendUrlFragment(boolean doSendUrlFragment) {
+    this.doSendUrlFragment = doSendUrlFragment;
+  }
+
+  public String getCookieNamePrefix() {
+    return cookieNamePrefix;
+  }
+
+  public void setCookieNamePrefix(String cookieNamePrefix) {
+    this.cookieNamePrefix = cookieNamePrefix;
+  }
+
+  public void setDoForwardIP(boolean doForwardIP) {
+    this.doForwardIP = doForwardIP;
+  }
+}

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -82,17 +82,11 @@ public class ProxyServlet extends HttpServlet {
 
   /** The parameter name for the target (destination) URI to proxy to. */
   protected static final String P_TARGET_URI = "targetUri";
-  protected static final String ATTR_TARGET_URI =
+  public static final String ATTR_TARGET_URI =
           ProxyServlet.class.getSimpleName() + ".targetUri";
-  protected static final String ATTR_TARGET_HOST =
+  public static final String ATTR_TARGET_HOST =
           ProxyServlet.class.getSimpleName() + ".targetHost";
 
-  /* MISC */
-
-  protected boolean doLog = false;
-  protected boolean doForwardIP = true;
-  /** User agents shouldn't send the url fragment but what if it does? */
-  protected boolean doSendUrlFragment = true;
 
   //These next 3 are cached here, and should only be referred to in initialization logic. See the
   // ATTR_* parameters.
@@ -101,7 +95,7 @@ public class ProxyServlet extends HttpServlet {
   protected URI targetUriObj;//new URI(targetUri)
   protected HttpHost targetHost;//URIUtils.extractHost(targetUriObj);
 
-  private HttpClient proxyClient;
+  Proxy proxy;
 
   @Override
   public String getServletInfo() {
@@ -117,6 +111,11 @@ public class ProxyServlet extends HttpServlet {
     return (HttpHost) servletRequest.getAttribute(ATTR_TARGET_HOST);
   }
 
+  /** The string prefixing rewritten cookies. */
+  protected String getCookieNamePrefix() {
+    return "!Proxy!" + getServletConfig().getServletName();
+  }
+
   /**
    * Reads a configuration parameter. By default it reads servlet init parameters but
    * it can be overridden.
@@ -127,22 +126,35 @@ public class ProxyServlet extends HttpServlet {
 
   @Override
   public void init() throws ServletException {
-    String doLogStr = getConfigParam(P_LOG);
-    if (doLogStr != null) {
-      this.doLog = Boolean.parseBoolean(doLogStr);
-    }
-
-    String doForwardIPString = getConfigParam(P_FORWARDEDFOR);
-    if (doForwardIPString != null) {
-        this.doForwardIP = Boolean.parseBoolean(doForwardIPString);
-    }
+    proxy = new Proxy();
 
     initTarget();//sets target*
 
     HttpParams hcParams = new BasicHttpParams();
     hcParams.setParameter(ClientPNames.COOKIE_POLICY, CookiePolicy.IGNORE_COOKIES);
     readConfigParam(hcParams, ClientPNames.HANDLE_REDIRECTS, Boolean.class);
-    proxyClient = createHttpClient(hcParams);
+    proxy.buildProxyClient(hcParams);
+
+    String doForwardIPString = getConfigParam(P_FORWARDEDFOR);
+    if (doForwardIPString != null) {
+      proxy.setDoForwardIP(Boolean.parseBoolean(doForwardIPString));
+    }
+
+    String doLogStr = getConfigParam(P_LOG);
+    if (doLogStr != null) {
+      proxy.setLogger(new Logger() {
+        @Override
+        public void logMessage(String s, Exception e) {
+          log(s, e);
+        }
+
+        @Override
+        public void logMessage(String s) {
+          log(s);
+        }
+      });
+    }
+    proxy.setCookieNamePrefix(getCookieNamePrefix());
   }
 
   protected void initTarget() throws ServletException {
@@ -158,35 +170,10 @@ public class ProxyServlet extends HttpServlet {
     targetHost = URIUtils.extractHost(targetUriObj);
   }
 
-  /** Called from {@link #init(javax.servlet.ServletConfig)}. HttpClient offers many opportunities
-   * for customization. By default,
-   * <a href="http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/SystemDefaultHttpClient.html">
-   *   SystemDefaultHttpClient</a> is used if available, otherwise it falls
-   * back to:
-   * <pre>new DefaultHttpClient(new ThreadSafeClientConnManager(),hcParams)</pre>
-   * SystemDefaultHttpClient uses PoolingClientConnectionManager. In any case, it should be thread-safe. */
-  @SuppressWarnings({"unchecked", "deprecation"})
-  protected HttpClient createHttpClient(HttpParams hcParams) {
-    try {
-      //as of HttpComponents v4.2, this class is better since it uses System
-      // Properties:
-      Class clientClazz = Class.forName("org.apache.http.impl.client.SystemDefaultHttpClient");
-      Constructor constructor = clientClazz.getConstructor(HttpParams.class);
-      return (HttpClient) constructor.newInstance(hcParams);
-    } catch (ClassNotFoundException e) {
-      //no problem; use v4.1 below
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-
-    //Fallback on using older client:
-    return new DefaultHttpClient(new ThreadSafeClientConnManager(), hcParams);
-  }
-
   /** The http client used.
-   * @see #createHttpClient(HttpParams) */
+   * @see #proxy.createHttpClient(HttpParams) */
   protected HttpClient getProxyClient() {
-    return proxyClient;
+    return proxy.getProxyClient();
   }
 
   /** Reads a servlet config parameter by the name {@code hcParamName} of type {@code type}, and
@@ -212,18 +199,8 @@ public class ProxyServlet extends HttpServlet {
 
   @Override
   public void destroy() {
-    //As of HttpComponents v4.3, clients implement closeable
-    if (proxyClient instanceof Closeable) {//TODO AutoCloseable in Java 1.6
-      try {
-        ((Closeable) proxyClient).close();
-      } catch (IOException e) {
-        log("While destroying servlet, shutting down HttpClient: "+e, e);
-      }
-    } else {
-      //Older releases require we do this:
-      if (proxyClient != null)
-        proxyClient.getConnectionManager().shutdown();
-    }
+    proxy.destroy();
+    proxy = null;
     super.destroy();
   }
 
@@ -231,389 +208,20 @@ public class ProxyServlet extends HttpServlet {
   protected void service(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
       throws ServletException, IOException {
     //initialize request attributes from caches if unset by a subclass by this point
-    if (servletRequest.getAttribute(ATTR_TARGET_URI) == null) {
-      servletRequest.setAttribute(ATTR_TARGET_URI, targetUri);
+    String _targetUri = (String)servletRequest.getAttribute(ATTR_TARGET_URI);
+    if (_targetUri == null) {
+      _targetUri = targetUri;
     }
-    if (servletRequest.getAttribute(ATTR_TARGET_HOST) == null) {
-      servletRequest.setAttribute(ATTR_TARGET_HOST, targetHost);
+    HttpHost _targetHost = (HttpHost)servletRequest.getAttribute(ATTR_TARGET_HOST);
+    if (_targetHost == null) {
+      _targetHost = targetHost;
     }
 
-    // Make the Request
-    //note: we won't transfer the protocol version because I'm not sure it would truly be compatible
-    String method = servletRequest.getMethod();
-    String proxyRequestUri = rewriteUrlFromRequest(servletRequest);
-    HttpRequest proxyRequest;
-    //spec: RFC 2616, sec 4.3: either of these two headers signal that there is a message body.
-    if (servletRequest.getHeader(HttpHeaders.CONTENT_LENGTH) != null ||
-        servletRequest.getHeader(HttpHeaders.TRANSFER_ENCODING) != null) {
-      HttpEntityEnclosingRequest eProxyRequest = new BasicHttpEntityEnclosingRequest(method, proxyRequestUri);
-      // Add the input entity (streamed)
-      //  note: we don't bother ensuring we close the servletInputStream since the container handles it
-      eProxyRequest.setEntity(new InputStreamEntity(servletRequest.getInputStream(), servletRequest.getContentLength()));
-      proxyRequest = eProxyRequest;
-    } else
-      proxyRequest = new BasicHttpRequest(method, proxyRequestUri);
-
-    copyRequestHeaders(servletRequest, proxyRequest);
-
-    setXForwardedForHeader(servletRequest, proxyRequest);
-
-    HttpResponse proxyResponse = null;
-    try {
-      // Execute the request
-      if (doLog) {
-        log("proxy " + method + " uri: " + servletRequest.getRequestURI() + " -- " + proxyRequest.getRequestLine().getUri());
-      }
-      proxyResponse = proxyClient.execute(getTargetHost(servletRequest), proxyRequest);
-
-      // Process the response
-      int statusCode = proxyResponse.getStatusLine().getStatusCode();
-
-      // copying response headers to make sure SESSIONID or other Cookie which comes from remote server
-      // will be saved in client when the proxied url was redirected to another one.
-      // see issue [#51](https://github.com/mitre/HTTP-Proxy-Servlet/issues/51)
-      copyResponseHeaders(proxyResponse, servletRequest, servletResponse);
-
-      if (doResponseRedirectOrNotModifiedLogic(servletRequest, servletResponse, proxyResponse, statusCode)) {
-        //the response is already "committed" now without any body to send
-        return;
-      }
-
-      // Pass the response code. This method with the "reason phrase" is deprecated but it's the only way to pass the
-      //  reason along too.
-      //noinspection deprecation
-      servletResponse.setStatus(statusCode, proxyResponse.getStatusLine().getReasonPhrase());
-
-      // Send the content to the client
-      copyResponseEntity(proxyResponse, servletResponse);
-
-    } catch (Exception e) {
-      //abort request, according to best practice with HttpClient
-      if (proxyRequest instanceof AbortableHttpRequest) {
-        AbortableHttpRequest abortableHttpRequest = (AbortableHttpRequest) proxyRequest;
-        abortableHttpRequest.abort();
-      }
-      if (e instanceof RuntimeException)
-        throw (RuntimeException)e;
-      if (e instanceof ServletException)
-        throw (ServletException)e;
-      //noinspection ConstantConditions
-      if (e instanceof IOException)
-        throw (IOException) e;
-      throw new RuntimeException(e);
-
-    } finally {
-      // make sure the entire entity was consumed, so the connection is released
-      if (proxyResponse != null)
-        consumeQuietly(proxyResponse.getEntity());
-      //Note: Don't need to close servlet outputStream:
-      // http://stackoverflow.com/questions/1159168/should-one-call-close-on-httpservletresponse-getoutputstream-getwriter
-    }
+    proxy.forward(servletRequest, servletResponse, _targetUri, _targetHost);
   }
 
-  protected boolean doResponseRedirectOrNotModifiedLogic(
-          HttpServletRequest servletRequest, HttpServletResponse servletResponse,
-          HttpResponse proxyResponse, int statusCode)
-          throws ServletException, IOException {
-    // Check if the proxy response is a redirect
-    // The following code is adapted from org.tigris.noodle.filters.CheckForRedirect
-    if (statusCode >= HttpServletResponse.SC_MULTIPLE_CHOICES /* 300 */
-        && statusCode < HttpServletResponse.SC_NOT_MODIFIED /* 304 */) {
-      Header locationHeader = proxyResponse.getLastHeader(HttpHeaders.LOCATION);
-      if (locationHeader == null) {
-        throw new ServletException("Received status code: " + statusCode
-            + " but no " + HttpHeaders.LOCATION + " header was found in the response");
-      }
-      // Modify the redirect to go to this proxy servlet rather that the proxied host
-      String locStr = rewriteUrlFromResponse(servletRequest, locationHeader.getValue());
-
-      servletResponse.sendRedirect(locStr);
-      return true;
-    }
-    // 304 needs special handling.  See:
-    // http://www.ics.uci.edu/pub/ietf/http/rfc1945.html#Code304
-    // We get a 304 whenever passed an 'If-Modified-Since'
-    // header and the data on disk has not changed; server
-    // responds w/ a 304 saying I'm not going to send the
-    // body because the file has not changed.
-    if (statusCode == HttpServletResponse.SC_NOT_MODIFIED) {
-      servletResponse.setIntHeader(HttpHeaders.CONTENT_LENGTH, 0);
-      servletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
-      return true;
-    }
-    return false;
-  }
-
-  protected void closeQuietly(Closeable closeable) {
-    try {
-      closeable.close();
-    } catch (IOException e) {
-      log(e.getMessage(), e);
-    }
-  }
-
-  /** HttpClient v4.1 doesn't have the
-   * {@link org.apache.http.util.EntityUtils#consumeQuietly(org.apache.http.HttpEntity)} method. */
-  protected void consumeQuietly(HttpEntity entity) {
-    try {
-      EntityUtils.consume(entity);
-    } catch (IOException e) {//ignore
-      log(e.getMessage(), e);
-    }
-  }
-
-  /** These are the "hop-by-hop" headers that should not be copied.
-   * http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
-   * I use an HttpClient HeaderGroup class instead of Set<String> because this
-   * approach does case insensitive lookup faster.
-   */
-  protected static final HeaderGroup hopByHopHeaders;
-  static {
-    hopByHopHeaders = new HeaderGroup();
-    String[] headers = new String[] {
-        "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
-        "TE", "Trailers", "Transfer-Encoding", "Upgrade" };
-    for (String header : headers) {
-      hopByHopHeaders.addHeader(new BasicHeader(header, null));
-    }
-  }
-
-  /** Copy request headers from the servlet client to the proxy request. */
-  protected void copyRequestHeaders(HttpServletRequest servletRequest, HttpRequest proxyRequest) {
-    // Get an Enumeration of all of the header names sent by the client
-    Enumeration enumerationOfHeaderNames = servletRequest.getHeaderNames();
-    while (enumerationOfHeaderNames.hasMoreElements()) {
-      String headerName = (String) enumerationOfHeaderNames.nextElement();
-      //Instead the content-length is effectively set via InputStreamEntity
-      if (headerName.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH))
-        continue;
-      if (hopByHopHeaders.containsHeader(headerName))
-        continue;
-
-      Enumeration headers = servletRequest.getHeaders(headerName);
-      while (headers.hasMoreElements()) {//sometimes more than one value
-        String headerValue = (String) headers.nextElement();
-        // In case the proxy host is running multiple virtual servers,
-        // rewrite the Host header to ensure that we get content from
-        // the correct virtual server
-        if (headerName.equalsIgnoreCase(HttpHeaders.HOST)) {
-          HttpHost host = getTargetHost(servletRequest);
-          headerValue = host.getHostName();
-          if (host.getPort() != -1)
-            headerValue += ":"+host.getPort();
-        } else if (headerName.equalsIgnoreCase(org.apache.http.cookie.SM.COOKIE)) {
-          headerValue = getRealCookie(headerValue);
-        }
-        proxyRequest.addHeader(headerName, headerValue);
-      }
-    }
-  }
-
-  private void setXForwardedForHeader(HttpServletRequest servletRequest,
-                                      HttpRequest proxyRequest) {
-    String headerName = "X-Forwarded-For";
-    if (doForwardIP) {
-      String newHeader = servletRequest.getRemoteAddr();
-      String existingHeader = servletRequest.getHeader(headerName);
-      if (existingHeader != null) {
-        newHeader = existingHeader + ", " + newHeader;
-      }
-      proxyRequest.setHeader(headerName, newHeader);
-    }
-  }
-
-  /** Copy proxied response headers back to the servlet client. */
-  protected void copyResponseHeaders(HttpResponse proxyResponse, HttpServletRequest servletRequest,
-                                     HttpServletResponse servletResponse) {
-    for (Header header : proxyResponse.getAllHeaders()) {
-      if (hopByHopHeaders.containsHeader(header.getName()))
-        continue;
-      if (header.getName().equalsIgnoreCase(org.apache.http.cookie.SM.SET_COOKIE) ||
-          header.getName().equalsIgnoreCase(org.apache.http.cookie.SM.SET_COOKIE2)) {
-        copyProxyCookie(servletRequest, servletResponse, header);
-      } else {
-        servletResponse.addHeader(header.getName(), header.getValue());
-      }
-    }
-  }
-
-  /** Copy cookie from the proxy to the servlet client.
-   *  Replaces cookie path to local path and renames cookie to avoid collisions.
-   */
-  protected void copyProxyCookie(HttpServletRequest servletRequest,
-                                 HttpServletResponse servletResponse, Header header) {
-    List<HttpCookie> cookies = HttpCookie.parse(header.getValue());
-    String path = servletRequest.getContextPath(); // path starts with / or is empty string
-    path += servletRequest.getServletPath(); // servlet path starts with / or is empty string
-
-    for (HttpCookie cookie : cookies) {
-      //set cookie name prefixed w/ a proxy value so it won't collide w/ other cookies
-      String proxyCookieName = getCookieNamePrefix() + cookie.getName();
-      Cookie servletCookie = new Cookie(proxyCookieName, cookie.getValue());
-      servletCookie.setComment(cookie.getComment());
-      servletCookie.setMaxAge((int) cookie.getMaxAge());
-      servletCookie.setPath(path); //set to the path of the proxy servlet
-      // don't set cookie domain
-      servletCookie.setSecure(cookie.getSecure());
-      servletCookie.setVersion(cookie.getVersion());
-      servletResponse.addCookie(servletCookie);
-    }
-  }
-
-  /** Take any client cookies that were originally from the proxy and prepare them to send to the
-   * proxy.  This relies on cookie headers being set correctly according to RFC 6265 Sec 5.4.
-   * This also blocks any local cookies from being sent to the proxy.
-   */
-  protected String getRealCookie(String cookieValue) {
-    StringBuilder escapedCookie = new StringBuilder();
-    String cookies[] = cookieValue.split("; ");
-    for (String cookie : cookies) {
-      String cookieSplit[] = cookie.split("=");
-      if (cookieSplit.length == 2) {
-        String cookieName = cookieSplit[0];
-        if (cookieName.startsWith(getCookieNamePrefix())) {
-          cookieName = cookieName.substring(getCookieNamePrefix().length());
-          if (escapedCookie.length() > 0) {
-            escapedCookie.append("; ");
-          }
-          escapedCookie.append(cookieName).append("=").append(cookieSplit[1]);
-        }
-      }
-
-      cookieValue = escapedCookie.toString();
-    }
-    return cookieValue;
-  }
-
-  /** The string prefixing rewritten cookies. */
-  protected String getCookieNamePrefix() {
-    return "!Proxy!" + getServletConfig().getServletName();
-  }
-
-  /** Copy response body data (the entity) from the proxy to the servlet client. */
-  protected void copyResponseEntity(HttpResponse proxyResponse, HttpServletResponse servletResponse) throws IOException {
-    HttpEntity entity = proxyResponse.getEntity();
-    if (entity != null) {
-      OutputStream servletOutputStream = servletResponse.getOutputStream();
-      entity.writeTo(servletOutputStream);
-    }
-  }
-
-  /** Reads the request URI from {@code servletRequest} and rewrites it, considering targetUri.
-   * It's used to make the new request.
-   */
-  protected String rewriteUrlFromRequest(HttpServletRequest servletRequest) {
-    StringBuilder uri = new StringBuilder(500);
-    uri.append(getTargetUri(servletRequest));
-    // Handle the path given to the servlet
-    if (servletRequest.getPathInfo() != null) {//ex: /my/path.html
-      uri.append(encodeUriQuery(servletRequest.getPathInfo()));
-    }
-    // Handle the query string & fragment
-    String queryString = servletRequest.getQueryString();//ex:(following '?'): name=value&foo=bar#fragment
-    String fragment = null;
-    //split off fragment from queryString, updating queryString if found
-    if (queryString != null) {
-      int fragIdx = queryString.indexOf('#');
-      if (fragIdx >= 0) {
-        fragment = queryString.substring(fragIdx + 1);
-        queryString = queryString.substring(0,fragIdx);
-      }
-    }
-
-    queryString = rewriteQueryStringFromRequest(servletRequest, queryString);
-    if (queryString != null && queryString.length() > 0) {
-      uri.append('?');
-      uri.append(encodeUriQuery(queryString));
-    }
-
-    if (doSendUrlFragment && fragment != null) {
-      uri.append('#');
-      uri.append(encodeUriQuery(fragment));
-    }
-    return uri.toString();
-  }
-
-  protected String rewriteQueryStringFromRequest(HttpServletRequest servletRequest, String queryString) {
-    return queryString;
-  }
-
-  /** For a redirect response from the target server, this translates {@code theUrl} to redirect to
-   * and translates it to one the original client can use. */
-  protected String rewriteUrlFromResponse(HttpServletRequest servletRequest, String theUrl) {
-    //TODO document example paths
-    final String targetUri = getTargetUri(servletRequest);
-    if (theUrl.startsWith(targetUri)) {
-      String curUrl = servletRequest.getRequestURL().toString();//no query
-      String pathInfo = servletRequest.getPathInfo();
-      if (pathInfo != null) {
-        assert curUrl.endsWith(pathInfo);
-        curUrl = curUrl.substring(0,curUrl.length()-pathInfo.length());//take pathInfo off
-      }
-      theUrl = curUrl+theUrl.substring(targetUri.length());
-    }
-    return theUrl;
-  }
 
   /** The target URI as configured. Not null. */
   public String getTargetUri() { return targetUri; }
-
-  /**
-   * Encodes characters in the query or fragment part of the URI.
-   *
-   * <p>Unfortunately, an incoming URI sometimes has characters disallowed by the spec.  HttpClient
-   * insists that the outgoing proxied request has a valid URI because it uses Java's {@link URI}.
-   * To be more forgiving, we must escape the problematic characters.  See the URI class for the
-   * spec.
-   *
-   * @param in example: name=value&foo=bar#fragment
-   */
-  protected static CharSequence encodeUriQuery(CharSequence in) {
-    //Note that I can't simply use URI.java to encode because it will escape pre-existing escaped things.
-    StringBuilder outBuf = null;
-    Formatter formatter = null;
-    for(int i = 0; i < in.length(); i++) {
-      char c = in.charAt(i);
-      boolean escape = true;
-      if (c < 128) {
-        if (asciiQueryChars.get((int)c)) {
-          escape = false;
-        }
-      } else if (!Character.isISOControl(c) && !Character.isSpaceChar(c)) {//not-ascii
-        escape = false;
-      }
-      if (!escape) {
-        if (outBuf != null)
-          outBuf.append(c);
-      } else {
-        //escape
-        if (outBuf == null) {
-          outBuf = new StringBuilder(in.length() + 5*3);
-          outBuf.append(in,0,i);
-          formatter = new Formatter(outBuf);
-        }
-        //leading %, 0 padded, width 2, capital hex
-        formatter.format("%%%02X",(int)c);//TODO
-      }
-    }
-    return outBuf != null ? outBuf : in;
-  }
-
-  protected static final BitSet asciiQueryChars;
-  static {
-    char[] c_unreserved = "_-!.~'()*".toCharArray();//plus alphanum
-    char[] c_punct = ",;:$&+=".toCharArray();
-    char[] c_reserved = "?/[]@".toCharArray();//plus punct
-
-    asciiQueryChars = new BitSet(128);
-    for(char c = 'a'; c <= 'z'; c++) asciiQueryChars.set((int)c);
-    for(char c = 'A'; c <= 'Z'; c++) asciiQueryChars.set((int)c);
-    for(char c = '0'; c <= '9'; c++) asciiQueryChars.set((int)c);
-    for(char c : c_unreserved) asciiQueryChars.set((int)c);
-    for(char c : c_punct) asciiQueryChars.set((int)c);
-    for(char c : c_reserved) asciiQueryChars.set((int)c);
-
-    asciiQueryChars.set((int)'%');//leave existing percent escapes in place
-  }
 
 }

--- a/src/main/java/org/mitre/dsmiley/httpproxy/QueryStringRewriter.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/QueryStringRewriter.java
@@ -1,0 +1,7 @@
+package org.mitre.dsmiley.httpproxy;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface QueryStringRewriter {
+  String rewriteQueryStringFromRequest(HttpServletRequest servletRequest, String queryString);
+}

--- a/src/main/java/org/mitre/dsmiley/httpproxy/URITemplateProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/URITemplateProxyServlet.java
@@ -53,6 +53,17 @@ public class URITemplateProxyServlet extends ProxyServlet {
   }
 
   @Override
+  public void init() throws ServletException {
+    super.init();
+    proxy.defineQueryStringRewriter(new QueryStringRewriter() {
+      @Override
+      public String rewriteQueryStringFromRequest(HttpServletRequest servletRequest, String queryString) {
+        return (String) servletRequest.getAttribute(ATTR_QUERY_STRING);
+      }
+    });
+  }
+
+  @Override
   protected void service(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
           throws ServletException, IOException {
 
@@ -116,10 +127,5 @@ public class URITemplateProxyServlet extends ProxyServlet {
     servletRequest.setAttribute(ATTR_QUERY_STRING, newQueryBuf.toString());
 
     super.service(servletRequest, servletResponse);
-  }
-
-  @Override
-  protected String rewriteQueryStringFromRequest(HttpServletRequest servletRequest, String queryString) {
-    return (String) servletRequest.getAttribute(ATTR_QUERY_STRING);
   }
 }


### PR DESCRIPTION
This is in the purpose of using the proxy in an independent way.

I haven't heavily tested this beyond the existing unit tests. Just fishing to see if this change makes sense for you before going further with it.