### PR TITLE
Clear Content-Length header when sending redirect to client.

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -327,6 +327,12 @@ public class ProxyServlet extends HttpServlet {
       // Modify the redirect to go to this proxy servlet rather that the proxied host
       String locStr = rewriteUrlFromResponse(servletRequest, locationHeader.getValue());
 
+      // Fix: #70 redirects do not use body
+      // When sending redirects a HttpServletResponse does not allow a body
+      // HttpServletResponse does not have a remove-header, so clear it instead
+      if (servletResponse.containsHeader(HttpHeaders.CONTENT_LENGTH)) {
+        servletResponse.setIntHeader(HttpHeaders.CONTENT_LENGTH, 0);
+      }
       servletResponse.sendRedirect(locStr);
       return true;
     }


### PR DESCRIPTION
Attempts to work-around Issue #70 by clearing the Content-Length header prior to sending a redirect.