### PR TITLE
Rework redirect handling to allow non-empty responses from the back-end server.

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -315,21 +315,6 @@ public class ProxyServlet extends HttpServlet {
           HttpServletRequest servletRequest, HttpServletResponse servletResponse,
           HttpResponse proxyResponse, int statusCode)
           throws ServletException, IOException {
-    // Check if the proxy response is a redirect
-    // The following code is adapted from org.tigris.noodle.filters.CheckForRedirect
-    if (statusCode >= HttpServletResponse.SC_MULTIPLE_CHOICES /* 300 */
-        && statusCode < HttpServletResponse.SC_NOT_MODIFIED /* 304 */) {
-      Header locationHeader = proxyResponse.getLastHeader(HttpHeaders.LOCATION);
-      if (locationHeader == null) {
-        throw new ServletException("Received status code: " + statusCode
-            + " but no " + HttpHeaders.LOCATION + " header was found in the response");
-      }
-      // Modify the redirect to go to this proxy servlet rather that the proxied host
-      String locStr = rewriteUrlFromResponse(servletRequest, locationHeader.getValue());
-
-      servletResponse.sendRedirect(locStr);
-      return true;
-    }
     // 304 needs special handling.  See:
     // http://www.ics.uci.edu/pub/ietf/http/rfc1945.html#Code304
     // We get a 304 whenever passed an 'If-Modified-Since'
@@ -431,6 +416,9 @@ public class ProxyServlet extends HttpServlet {
       if (header.getName().equalsIgnoreCase(org.apache.http.cookie.SM.SET_COOKIE) ||
           header.getName().equalsIgnoreCase(org.apache.http.cookie.SM.SET_COOKIE2)) {
         copyProxyCookie(servletRequest, servletResponse, header);
+      } else if (header.getName().equalsIgnoreCase(HttpHeaders.LOCATION)) {
+        // LOCATION Header may have to be rewritten.
+        servletResponse.addHeader(header.getName(), rewriteUrlFromResponse(servletRequest, header.getValue()));
       } else {
         servletResponse.addHeader(header.getName(), header.getValue());
       }


### PR DESCRIPTION
Another attempt to solve #70 redirects with body response.
