### PR TITLE
Revert "Clear Content-Length header when sending redirect to client."

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -327,12 +327,6 @@ public class ProxyServlet extends HttpServlet {
       // Modify the redirect to go to this proxy servlet rather that the proxied host
       String locStr = rewriteUrlFromResponse(servletRequest, locationHeader.getValue());
 
-      // Fix: #70 redirects do not use body
-      // When sending redirects a HttpServletResponse does not allow a body
-      // HttpServletResponse does not have a remove-header, so clear it instead
-      if (servletResponse.containsHeader(HttpHeaders.CONTENT_LENGTH)) {
-        servletResponse.setIntHeader(HttpHeaders.CONTENT_LENGTH, 0);
-      }
       servletResponse.sendRedirect(locStr);
       return true;
     }

--- a/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
@@ -325,31 +325,6 @@ public class ProxyServletTest
     assertEquals("USER_2_SESSION", sc.getCookieJar().getCookie("!Proxy!" + servletName + "JSESSIONID").getValue());
   }
 
-  @Test
-  public void testRedirectWithBody() throws Exception {
-    localTestServer.register("/targetPath/test",new HttpRequestHandler()
-    {
-      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
-        // Redirect to the requested URL with / appended
-        response.setHeader(HttpHeaders.LOCATION, targetBaseUri + "/test/");
-        response.setStatusCode(HttpStatus.SC_MOVED_TEMPORARILY);
-        // Set body of the response. We need it not-empty for the test.
-        response.setEntity(new ByteArrayEntity("-This-Shall-Not-Pass-".getBytes("UTF-8")));
-      }
-    });
-    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri + "/test");
-    // We expect a redirect with a / at the end
-    WebResponse rsp = sc.getResponse(req);
-
-    // Expect the same status code as the handler.
-    assertEquals(HttpStatus.SC_MOVED_TEMPORARILY, rsp.getResponseCode());
-    // Expect zero Content-Length
-    assertEquals("0", rsp.getHeaderField(HttpHeaders.CONTENT_LENGTH));
-    // Expect blank response
-    assertEquals("", rsp.getText());
-    assertEquals(sourceBaseUri + "/test/", rsp.getHeaderField(HttpHeaders.LOCATION));
-  }
-
   private WebResponse execAssert(GetMethodWebRequest request, String expectedUri) throws Exception {
     return execAndAssert(request, expectedUri);
   }


### PR DESCRIPTION
Reverts mitre/HTTP-Proxy-Servlet#71