### PR TITLE
overridable methods for extending classes to modify header before request/response is done

### DIFF
--- a/src/test/java/org/mitre/dsmiley/httpproxy/ModifyHeadersProxyServletTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ModifyHeadersProxyServletTest.java
@@ -1,0 +1,81 @@
+package org.mitre.dsmiley.httpproxy;
+
+import com.meterware.httpunit.GetMethodWebRequest;
+import com.meterware.httpunit.WebResponse;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * tests to show that by extending ProxyServlet we can override methods coping headers to proxied response and from it
+ */
+public class ModifyHeadersProxyServletTest extends ProxyServletTest {
+
+  @Override
+  public void setUp() throws Exception {
+    servletName = ModifyHeadersProxyServlet.class.getName();
+    super.setUp();
+  }
+
+  @Test
+  public void testModifyRequestHeader() throws Exception {
+    localTestServer.register("/targetPath*", new RequestInfoHandler() {
+      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        Header headerToTest = request.getFirstHeader(ModifyHeadersProxyServlet.REQUEST_HEADER);
+        assertEquals("REQUEST_VALUE_MODIFIED", headerToTest.getValue());
+
+        super.handle(request, response, context);
+      }
+    });
+
+    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
+    req.setHeaderField(ModifyHeadersProxyServlet.REQUEST_HEADER, "INITIAL_VALUE");
+
+    execAndAssert(req, "");
+  }
+
+  @Test
+  public void testModifyResponseHeader() throws Exception {
+    localTestServer.register("/targetPath*", new RequestInfoHandler() {
+      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        response.setHeader(ModifyHeadersProxyServlet.RESPONSE_HEADER, "INITIAL_VALUE");
+        super.handle(request, response, context);
+      }
+    });
+
+    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
+    WebResponse rsp = execAndAssert(req, "");
+
+    assertEquals("RESPONSE_VALUE_MODIFIED", rsp.getHeaderField(ModifyHeadersProxyServlet.RESPONSE_HEADER));
+  }
+
+  public static class ModifyHeadersProxyServlet extends ProxyServlet {
+    public static final String REQUEST_HEADER = "REQUEST_HEADER";
+    public static final String RESPONSE_HEADER = "RESPONSE_HEADER";
+
+    @Override
+    protected void addHeaderToProxyRequest(HttpRequest proxyRequest, String headerName, String headerValue) {
+      if (REQUEST_HEADER.equalsIgnoreCase(headerName)) {
+        headerValue = "REQUEST_VALUE_MODIFIED";
+      }
+      proxyRequest.addHeader(headerName, headerValue);
+    }
+
+    @Override
+    protected void addHeaderToResponse(HttpServletResponse servletResponse, String headerName, String headerValue) {
+      if (RESPONSE_HEADER.equalsIgnoreCase(headerName)) {
+        headerValue = "RESPONSE_VALUE_MODIFIED";
+      }
+      servletResponse.addHeader(headerName, headerValue);
+    }
+
+  }
+}

--- a/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
@@ -231,6 +231,42 @@ public class ProxyServletTest
   }
 
   @Test
+  public void testCopyRequestHeaderToProxyRequest() throws Exception {
+    final String HEADER = "HEADER_TO_TEST";
+
+    localTestServer.register("/targetPath*", new RequestInfoHandler() {
+      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        Header headerToTest = request.getFirstHeader(HEADER);
+        assertEquals("VALUE_TO_TEST", headerToTest.getValue());
+
+        super.handle(request, response, context);
+      }
+    });
+
+    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
+    req.setHeaderField(HEADER, "VALUE_TO_TEST");
+
+    execAndAssert(req, "");
+  }
+
+  @Test
+  public void testCopyProxiedRequestHeadersToResponse() throws Exception {
+    final String HEADER = "HEADER_TO_TEST";
+
+    localTestServer.register("/targetPath*", new RequestInfoHandler() {
+      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        response.setHeader(HEADER, "VALUE_TO_TEST");
+        super.handle(request, response, context);
+      }
+    });
+
+    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
+
+    WebResponse rsp = execAndAssert(req, "");
+    assertEquals("VALUE_TO_TEST", rsp.getHeaderField(HEADER));
+  }
+
+  @Test
   public void testSetCookie() throws Exception {
     final String HEADER = "Set-Cookie";
     localTestServer.register("/targetPath*", new RequestInfoHandler() {
@@ -379,7 +415,7 @@ public class ProxyServletTest
     return rsp;
   }
 
-  private WebResponse execAndAssert(WebRequest request, String expectedUri) throws Exception {
+  protected WebResponse execAndAssert(WebRequest request, String expectedUri) throws Exception {
     WebResponse rsp = sc.getResponse( request );
 
     assertEquals(HttpStatus.SC_OK,rsp.getResponseCode());
@@ -413,7 +449,7 @@ public class ProxyServletTest
     return new URI(this.targetBaseUri).getPath() + expectedUri;
   }
 
-  private GetMethodWebRequest makeGetMethodRequest(final String url) {
+  protected GetMethodWebRequest makeGetMethodRequest(final String url) {
     return makeMethodRequest(url,GetMethodWebRequest.class);
   }
 
@@ -473,7 +509,7 @@ public class ProxyServletTest
   /**
    * Writes all information about the request back to the response.
    */
-  private static class RequestInfoHandler implements HttpRequestHandler
+  protected static class RequestInfoHandler implements HttpRequestHandler
   {
 
     public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {


### PR DESCRIPTION
overridable methods for extending classes to implement logic relate headers copied from request to proxy request and from proxied request to servlet response.

These methods are convenient to remove authentication headers from requests