### PR TITLE
Added new parameters to configure headers

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -81,6 +81,12 @@ public class ProxyServlet extends HttpServlet {
   /** A boolean parameter name to enable forwarding of the client IP  */
   public static final String P_FORWARDEDFOR = "forwardip";
 
+  /** A boolean parameter name to keep HOST parameter as-is  */
+  public static final String P_PRESERVEHOST = "preserveHost";
+
+  /** A boolean parameter name to keep COOKIES as-is  */
+  public static final String P_PRESERVECOOKIES = "preserveCookies";
+
   /** The parameter name for the target (destination) URI to proxy to. */
   protected static final String P_TARGET_URI = "targetUri";
   protected static final String ATTR_TARGET_URI =
@@ -94,7 +100,9 @@ public class ProxyServlet extends HttpServlet {
   protected boolean doForwardIP = true;
   /** User agents shouldn't send the url fragment but what if it does? */
   protected boolean doSendUrlFragment = true;
-
+  protected boolean doPreserveHost = false;
+  protected boolean doPreserveCookies = false;
+  
   //These next 3 are cached here, and should only be referred to in initialization logic. See the
   // ATTR_* parameters.
   /** From the configured parameter "targetUri". */
@@ -138,6 +146,15 @@ public class ProxyServlet extends HttpServlet {
         this.doForwardIP = Boolean.parseBoolean(doForwardIPString);
     }
 
+    String preserveHostString = getConfigParam(P_PRESERVEHOST);
+    if (preserveHostString != null) {
+        this.doPreserveHost = Boolean.parseBoolean(preserveHostString);
+    }
+
+    String preserveCookiesString = getConfigParam(P_PRESERVECOOKIES);
+    if (preserveCookiesString != null) {
+        this.doPreserveCookies = Boolean.parseBoolean(preserveCookiesString);
+    }
     initTarget();//sets target*
 
     HttpParams hcParams = new BasicHttpParams();
@@ -396,12 +413,12 @@ public class ProxyServlet extends HttpServlet {
       // In case the proxy host is running multiple virtual servers,
       // rewrite the Host header to ensure that we get content from
       // the correct virtual server
-      if (headerName.equalsIgnoreCase(HttpHeaders.HOST)) {
+      if (!doPreserveHost && headerName.equalsIgnoreCase(HttpHeaders.HOST)) {
         HttpHost host = getTargetHost(servletRequest);
         headerValue = host.getHostName();
         if (host.getPort() != -1)
           headerValue += ":"+host.getPort();
-      } else if (headerName.equalsIgnoreCase(org.apache.http.cookie.SM.COOKIE)) {
+      } else if (!doPreserveCookies && headerName.equalsIgnoreCase(org.apache.http.cookie.SM.COOKIE)) {
         headerValue = getRealCookie(headerValue);
       }
       proxyRequest.addHeader(headerName, headerValue);
@@ -411,13 +428,17 @@ public class ProxyServlet extends HttpServlet {
   private void setXForwardedForHeader(HttpServletRequest servletRequest,
                                       HttpRequest proxyRequest) {
     if (doForwardIP) {
-      String headerName = "X-Forwarded-For";
-      String newHeader = servletRequest.getRemoteAddr();
-      String existingHeader = servletRequest.getHeader(headerName);
-      if (existingHeader != null) {
-        newHeader = existingHeader + ", " + newHeader;
+      String forHeaderName = "X-Forwarded-For";
+      String forHeader = servletRequest.getRemoteAddr();
+      String existingForHeader = servletRequest.getHeader(forHeaderName);
+      if (existingForHeader != null) {
+        forHeader = existingForHeader + ", " + forHeader;
       }
-      proxyRequest.setHeader(headerName, newHeader);
+      proxyRequest.setHeader(forHeaderName, forHeader);
+
+      String protoHeaderName = "X-Forwarded-Proto";
+      String protoHeader = servletRequest.getScheme();
+      proxyRequest.setHeader(protoHeaderName, protoHeader);
     }
   }
 
@@ -460,7 +481,7 @@ public class ProxyServlet extends HttpServlet {
 
     for (HttpCookie cookie : cookies) {
       //set cookie name prefixed w/ a proxy value so it won't collide w/ other cookies
-      String proxyCookieName = getCookieNamePrefix(cookie.getName()) + cookie.getName();
+      String proxyCookieName = doPreserveCookies ? cookie.getName() : getCookieNamePrefix(cookie.getName()) + cookie.getName();
       Cookie servletCookie = new Cookie(proxyCookieName, cookie.getValue());
       servletCookie.setComment(cookie.getComment());
       servletCookie.setMaxAge((int) cookie.getMaxAge());

--- a/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
@@ -217,29 +217,32 @@ public class ProxyServletTest
 
   @Test
   public void testWithExistingXForwardedFor() throws Exception {
-    final String HEADER = "X-Forwarded-For";
+    final String FOR_HEADER = "X-Forwarded-For";
 
     localTestServer.register("/targetPath*", new RequestInfoHandler() {
       public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
-        Header xForwardedForHeader = request.getFirstHeader(HEADER);
+        Header xForwardedForHeader = request.getFirstHeader(FOR_HEADER);
         assertEquals("192.168.1.1, 127.0.0.1", xForwardedForHeader.getValue());
         super.handle(request, response, context);
       }
     });
 
     GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
-    req.setHeaderField(HEADER, "192.168.1.1");
+    req.setHeaderField(FOR_HEADER, "192.168.1.1");
     WebResponse rsp = execAndAssert(req, "");
   }
 
   @Test
   public void testEnabledXForwardedFor() throws Exception {
-    final String HEADER = "X-Forwarded-For";
+    final String FOR_HEADER = "X-Forwarded-For";
+    final String PROTO_HEADER = "X-Forwarded-Proto";
 
     localTestServer.register("/targetPath*", new RequestInfoHandler() {
       public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
-        Header xForwardedForHeader = request.getFirstHeader(HEADER);
+        Header xForwardedForHeader = request.getFirstHeader(FOR_HEADER);
+        Header xForwardedProtoHeader = request.getFirstHeader(PROTO_HEADER);
         assertEquals("127.0.0.1", xForwardedForHeader.getValue());
+        assertEquals("http", xForwardedProtoHeader.getValue());
         super.handle(request, response, context);
       }
     });
@@ -315,6 +318,34 @@ public class ProxyServletTest
     // note httpunit doesn't set all cookie fields, ignores max-agent, secure, etc.
     // also doesn't support more than one header of same name so I can't test this working on two cookies
     assertEquals("!Proxy!" + servletName + "JSESSIONID=1234;path=" + servletPath, rsp.getHeaderField("Set-Cookie"));
+  }
+
+  @Test
+  public void testPreserveCookie() throws Exception {
+    servletRunner = new ServletRunner();
+
+    Properties servletProps = new Properties();
+    servletProps.setProperty("http.protocol.handle-redirects", "false");
+    servletProps.setProperty(ProxyServlet.P_LOG, "true");
+    servletProps.setProperty(ProxyServlet.P_FORWARDEDFOR, "true");
+    servletProps.setProperty(ProxyServlet.P_PRESERVECOOKIES, "true");
+    setUpServlet(servletProps);
+
+    sc = servletRunner.newClient();
+    sc.getClientProperties().setAutoRedirect(false);//don't want httpunit itself to redirect
+
+    final String HEADER = "Set-Cookie";
+    localTestServer.register("/targetPath*", new RequestInfoHandler() {
+      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        response.setHeader(HEADER, "JSESSIONID=1234; Path=/proxy/path/that/we/dont/want; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Domain=.foo.bar.com; HttpOnly");
+        super.handle(request, response, context);
+      }
+    });
+
+    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
+    WebResponse rsp = execAndAssert(req, "");
+    // note httpunit doesn't set all cookie fields, ignores max-agent, secure, etc.
+    assertEquals("JSESSIONID=1234;path=" + servletPath, rsp.getHeaderField(HEADER));
   }
 
   @Test
@@ -414,6 +445,35 @@ public class ProxyServletTest
     // Expect exact response
     assertEquals(CONTENT, rsp.getText());
     assertEquals(sourceBaseUri + "/test/", rsp.getHeaderField(HttpHeaders.LOCATION));
+  }
+
+  @Test
+  public void testPreserveHost() throws Exception {
+    servletRunner = new ServletRunner();
+
+    Properties servletProps = new Properties();
+    servletProps.setProperty("http.protocol.handle-redirects", "false");
+    servletProps.setProperty(ProxyServlet.P_LOG, "true");
+    servletProps.setProperty(ProxyServlet.P_FORWARDEDFOR, "true");
+    servletProps.setProperty(ProxyServlet.P_PRESERVEHOST, "true");
+    setUpServlet(servletProps);
+
+    sc = servletRunner.newClient();
+    sc.getClientProperties().setAutoRedirect(false);//don't want httpunit itself to redirect
+
+    final String HEADER = "Host";
+    final String[] proxyHost = new String[1];
+    localTestServer.register("/targetPath*", new RequestInfoHandler() {
+      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+    	  proxyHost[0] = request.getHeaders(HEADER)[0].getValue();
+        super.handle(request, response, context);
+      }
+    });
+
+    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
+    req.setHeaderField(HEADER, "SomeHost");
+    execAndAssert(req, "");
+    assertEquals("SomeHost", proxyHost[0]);
   }
 
   private WebResponse execAssert(GetMethodWebRequest request, String expectedUri) throws Exception {


### PR DESCRIPTION
* Added "preserveHost" configuration to preserve the original Host
header from the browser
* Added "preserveCookies" configuration to preserve the original cookie
names from the browser
* Added X-Forwarded-Proto to be set along side X-Forwarded-For