### PR TITLE
support for variables in 'param-value' from properties file without depending on any 3rd party libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ HTTP POST. Other application parameters can be in your POSTed url-encoded-form s
 proxyArgs.
 
 Build & Installation
-------------
+--------------------
 
 Simply build the jar using "mvn package" at the command line.
 The jar is built to "target/smiley-http-proxy-servlet-VERSION.jar".
@@ -49,7 +49,7 @@ add this to your dependencies in your pom like so:
     <dependency>
         <groupId>org.mitre.dsmiley.httpproxy</groupId>
         <artifactId>smiley-http-proxy-servlet</artifactId>
-        <version>1.7</version>
+        <version>1.9.1</version>
     </dependency>
 
 Ivy and other dependency managers can be used as well.
@@ -136,4 +136,43 @@ proxy:
     solr:
         servlet_url: /solr/*
         target_url: http://solrserver:8983/solr
+```
+
+Here is an example of using the proxy with an externalized properties file `http-proxy.properties` and / or `http-proxy-override.properties` which would be plugged into the `web.xml` if it is available in the classpath:
+
+```xml
+    ...
+    <servlet>
+        <servlet-name>solr</servlet-name>
+        <servlet-class>org.mitre.dsmiley.httpproxy.ProxyServlet</servlet-class>
+        <init-param>
+          <param-name>targetUri</param-name>
+          <param-value>${some-url}</param-value>
+        </init-param>
+        <init-param>
+          <param-name>log</param-name>
+          <param-value>true</param-value>
+        </init-param>
+    </servlet>
+    ...
+```
+
+make sure you put **${**some-url**}** is used if you want to pickup values from the properties file.
+
+The properties file could be:
+
+**http-proxy.properties**:
+  
+```properties
+some-url=http://www.cisco.com/{x-some-parameter}/someEndpoint
+```
+
+Assuming `x-some-parameter`  is a custom header parameter.
+
+If this property needs to be overridden for some reason for a different environment for example, then the override properties file could be:
+
+**http-proxy-override.properties**
+
+```properties
+some-url=http://www.cisco.com/someContext/someEndpoint
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an HTTP Proxy (aka gateway) in the form of a Java servlet.  An HTTP prox
 This is hardly the first proxy, so why did I write it and thus why might you use it?
 
  * It's simple -- a single source file implementation
- * It's tested -- have confidence it works [![Build Status](https://travis-ci.org/mitre/HTTP-Proxy-Servlet.png)](https://travis-ci.org/mitre/HTTP-Proxy-Servlet)
+ * It's tested -- have confidence it works [![Build Status](https://travis-ci.org/madhbhavikar/HTTP-Proxy-Servlet.svg?branch=master)](https://travis-ci.org/madhbhavikar/HTTP-Proxy-Servlet)
  * It's securable -- via Java EE web.xml or via a servlet filter such as [Spring-Security]([http://static.springsource.org/spring-security/site/)
  * It's extendible -- via simple class extension
  * It's embeddable -- into your Java web application making testing your app easier

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.mitre.dsmiley.httpproxy</groupId>
   <artifactId>smiley-http-proxy-servlet</artifactId>
-  <version>1.9-SNAPSHOT</version>
+  <version>1.9.1</version>
   <packaging>jar</packaging>
 
   <name>Smiley's HTTP Proxy Servlet</name>
@@ -29,13 +29,25 @@
       <!-- I used to work for MITRE for many years but I don't anymore. -->
       <!--<organization>MITRE</organization>-->
     </developer>
+    <developer>
+      <name>Prasad Madhbhavikar</name>
+      <email>prasad.madhbhavikar@gmail.com</email>
+      <!-- Currently working with Cisco and the changes are as requested -->
+      <organization>Cisco</organization>
+    </developer>
+    <developer>
+      <name>Gourav Jangra</name>
+      <email>jangra.gourav143@gmail.com</email>
+      <!-- Currently working with Cisco and the changes are as requested -->
+      <organization>Cisco</organization>
+    </developer>
   </developers>
 
   <scm>
     <url>https://github.com/dsmiley/HTTP-Proxy-Servlet</url>
     <connection>scm:git:https://dsmiley@github.com/dsmiley/HTTP-Proxy-Servlet.git</connection>
     <developerConnection>scm:git:git@github.com:dsmiley/HTTP-Proxy-Servlet.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>smiley-http-proxy-servlet-1.9</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
Support for properties file
Fix for possible memory leak in formatter
Support for properties file
Documentation updated
version bumped to 1.9.1

Reference : [Previous pull request](https://github.com/mitre/HTTP-Proxy-Servlet/pull/105)