### PR TITLE
Downgrade java version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <!-- Note: Java 1.6 has an issue parsing an HttpOnly flag in a Set-Cookie header, but
           otherwise works. -->
           <compilerArgs>


### PR DESCRIPTION
Since both the library and all it's dependencies (httpclient is built with target set to 1.6) are compatible with Java 6, it should be safe to downgrade the source/target java version to 1.6.

Without this, I'm running into the following error when running on JDK6:
java.lang.UnsupportedClassVersionError: org/mitre/dsmiley/httpproxy/ProxyServlet : Unsupported major.minor version 51.0