### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ add this to your dependencies in your pom like so:
     <dependency>
         <groupId>org.mitre.dsmiley.httpproxy</groupId>
         <artifactId>smiley-http-proxy-servlet</artifactId>
-        <version>1.7</version>
+        <version>1.8</version>
     </dependency>
 
 Ivy and other dependency managers can be used as well.


### PR DESCRIPTION
Since August 2016, a 1.8 version is available in Maven Central. The README.md is updated to show this fact.