### PR TITLE
Don't forward proto if we receive the header

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -91,7 +91,7 @@ public class ProxyServlet extends HttpServlet {
 
   /** A integer parameter name to set the socket read timeout (millis) */
   public static final String P_READTIMEOUT = "http.read.timeout";
-  
+
   /** The parameter name for the target (destination) URI to proxy to. */
   protected static final String P_TARGET_URI = "targetUri";
   protected static final String ATTR_TARGET_URI =
@@ -173,7 +173,7 @@ public class ProxyServlet extends HttpServlet {
     if (connectTimeoutString != null) {
       this.connectTimeout = Integer.parseInt(connectTimeoutString);
     }
-    
+
     String readTimeoutString = getConfigParam(P_READTIMEOUT);
     if (readTimeoutString != null) {
       this.readTimeout = Integer.parseInt(readTimeoutString);
@@ -388,8 +388,8 @@ public class ProxyServlet extends HttpServlet {
     }
   }
 
-  /** 
-   * Copy request headers from the servlet client to the proxy request. 
+  /**
+   * Copy request headers from the servlet client to the proxy request.
    * This is easily overridden to add your own.
    */
   protected void copyRequestHeaders(HttpServletRequest servletRequest, HttpRequest proxyRequest) {
@@ -446,6 +446,10 @@ public class ProxyServlet extends HttpServlet {
 
       String protoHeaderName = "X-Forwarded-Proto";
       String protoHeader = servletRequest.getScheme();
+      String existingProtoHeader = servletRequest.getHeader(protoHeaderName);
+      if (existingProtoHeader != null) {
+          protoHeader = existingProtoHeader;
+      }
       proxyRequest.setHeader(protoHeaderName, protoHeader);
     }
   }

--- a/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
@@ -233,6 +233,24 @@ public class ProxyServletTest
   }
 
   @Test
+  public void testWithExistingXForwardedProto() throws Exception {
+    final String PROTO_HEADER = "X-Forwarded-Proto";
+
+    localTestServer.register("/targetPath*", new RequestInfoHandler() {
+      public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        Header xForwardedProtoHeader = request.getFirstHeader(PROTO_HEADER);
+        assertEquals("https", xForwardedProtoHeader.getValue());
+        super.handle(request, response, context);
+      }
+    });
+
+    GetMethodWebRequest req = makeGetMethodRequest(sourceBaseUri);
+    req.setHeaderField(PROTO_HEADER, "https");
+    WebResponse rsp = execAndAssert(req, "");
+  }
+
+
+  @Test
   public void testEnabledXForwardedFor() throws Exception {
     final String FOR_HEADER = "X-Forwarded-For";
     final String PROTO_HEADER = "X-Forwarded-Proto";


### PR DESCRIPTION
This change is a bit more controversial than the previous one.  Feel free to decline if it doesn't suit.

When upgrading from version 1.7 to version 1.10, we found the X-Forwarded-Proto header was no longer being honoured when passing through the proxy.  The header was being replaced.

For X-Forwarded-For, the behaviour was easier since we can add the IP to the list. However my understanding is that X-Forwarded-Proto it is not a list. We could disable forwardip, or just ignore current protocol if we have a header. 

