### PR TITLE
ProxyServlet copyResponseHeaders double #80

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Thanks Thorsten Möller.
 request that had no query portion of the URL.
 Thanks @pjunlin.
 
+\#80: If the proxy target added CORS headers as well as the proxy web application itself, 
+the header "Access-Control-Allow-Origin" gets doubled and browsers reject this, 
+referring to CORB.
+
 README updates.  Thanks Bruce Taylor, Gonzalo Fernández-Victorio
 
 # Version 1.10, 2017-11-26

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -386,7 +386,9 @@ public class ProxyServlet extends HttpServlet {
     hopByHopHeaders = new HeaderGroup();
     String[] headers = new String[] {
         "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization",
-        "TE", "Trailers", "Transfer-Encoding", "Upgrade" };
+        "TE", "Trailers", "Transfer-Encoding", "Upgrade",
+        // CORS related headers are not defined in rfc2616 but are also "hop-by-hop" only, browsers block it if doubled.
+        "Access-Control-Allow-Origin" };
     for (String header : headers) {
       hopByHopHeaders.addHeader(new BasicHeader(header, null));
     }


### PR DESCRIPTION
If the proxy target added CORS headers as well as the proxy web application itself,
the header "Access-Control-Allow-Origin" gets doubled and browsers reject this,
referring to CORB. Therefore this header is added to the ignored response hop-by-hop headers.