### PR TITLE
Setting the read timeout in the RequestConfig is not enough.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 
 # Version 1.11 (unreleased)
 
+\#150 Setting the read timeout in the RequestConfig is not enough.
+The read timeout must be set in the SocketConfig as well.
+Setting the read timeout only in the RequestConfig can cause hangs which could
+block the whole proxy forever.
+Attention: Method signature of createHttpClient(RequestConfig) changed to
+createHttpClient().
+Please override buildRequestConfig() and buildSocketConfig() to configure the
+Apache HttpClient.
+Thanks Martin Wegner.
+
 \#139: Use Java system properties for http proxy (and other settings) by default.
 This is a regression; it used to work this way in 1.8 and prior.
 Thanks Thorsten Möller.

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -211,7 +211,7 @@ public class ProxyServlet extends HttpServlet {
    */
   protected SocketConfig buildSocketConfig() {
     return SocketConfig.custom()
-            .setSoTimeout(readTimeout)
+            .setSoTimeout(readTimeout == -1 ? 0 : readTimeout)
             .build();
   }
 

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -244,7 +244,7 @@ public class ProxyServlet extends HttpServlet {
 
   /**
    * The http client used.
-   * @see #createHttpClient(RequestConfig)
+   * @see #createHttpClient(RequestConfig, SocketConfig)
    */
   protected HttpClient getProxyClient() {
     return proxyClient;


### PR DESCRIPTION
The read timeout must be set in the SocketConfig as well.

Setting the read timeout only in the RequestConfig can cause hangs which
could block the whole proxy forever.