### PR TITLE
Copy HttpOnly flag in proxy cookie

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 
 # Version 1.11 (unreleased)
 
+\#151: Copy `HttpOnly` flag of proxy coookie to request clients, for fixing security vulnerabilities in cookies.
+This also updates `javax.servlet-api` to `v3.0.1`.
+
 \#139: Use Java system properties for http proxy (and other settings) by default.
 This is a regression; it used to work this way in 1.8 and prior.
 Thanks Thorsten Möller.

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
     <!-- FYI tomcat 5.5 & beyond -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -505,6 +505,7 @@ public class ProxyServlet extends HttpServlet {
       // don't set cookie domain
       servletCookie.setSecure(cookie.getSecure());
       servletCookie.setVersion(cookie.getVersion());
+      servletCookie.setHttpOnly(cookie.isHttpOnly());
       servletResponse.addCookie(servletCookie);
     }
   }


### PR DESCRIPTION
HttpOnly flag is missed when copying proxy cookies to request client.