### PR TITLE
Configurable Connection Request Timeout

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -91,6 +91,9 @@ public class ProxyServlet extends HttpServlet {
 
   /** A integer parameter name to set the socket read timeout (millis) */
   public static final String P_READTIMEOUT = "http.read.timeout";
+  
+  /** A integer parameter name to set the connection request timeout (millis) */
+  public static final String P_CONNECTIONREQUESTTIMEOUT = "http.connectionrequest.timeout";
 
   /** A boolean parameter whether to use JVM-defined system properties to configure various networking aspects. */
   public static final String P_USESYSTEMPROPERTIES = "useSystemProperties";
@@ -114,6 +117,7 @@ public class ProxyServlet extends HttpServlet {
   protected boolean useSystemProperties = true;
   protected int connectTimeout = -1;
   protected int readTimeout = -1;
+  protected int connectionRequestTimeout = -1;
 
   //These next 3 are cached here, and should only be referred to in initialization logic. See the
   // ATTR_* parameters.
@@ -182,6 +186,11 @@ public class ProxyServlet extends HttpServlet {
     if (readTimeoutString != null) {
       this.readTimeout = Integer.parseInt(readTimeoutString);
     }
+    
+    String connectionRequestTimeout = getConfigParam(P_CONNECTIONREQUESTTIMEOUT);
+    if (connectionRequestTimeout != null) {
+      this.connectionRequestTimeout = Integer.parseInt(connectionRequestTimeout);
+    }
 
     String useSystemPropertiesString = getConfigParam(P_USESYSTEMPROPERTIES);
     if (useSystemPropertiesString != null) {
@@ -202,6 +211,7 @@ public class ProxyServlet extends HttpServlet {
             .setCookieSpec(CookieSpecs.IGNORE_COOKIES) // we handle them in the servlet instead
             .setConnectTimeout(connectTimeout)
             .setSocketTimeout(readTimeout)
+            .setConnectionRequestTimeout(connectionRequestTimeout)
             .build();
   }
 

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -31,6 +31,7 @@ import org.apache.http.client.utils.URIUtils;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicHttpEntityEnclosingRequest;
 import org.apache.http.message.BasicHttpRequest;
@@ -95,6 +96,9 @@ public class ProxyServlet extends HttpServlet {
   /** A integer parameter name to set the connection request timeout (millis) */
   public static final String P_CONNECTIONREQUESTTIMEOUT = "http.connectionrequest.timeout";
 
+  /** A integer parameter name to set max connection number */
+  public static final String P_MAXCONNECTIONS = "http.maxConnections";
+  
   /** A boolean parameter whether to use JVM-defined system properties to configure various networking aspects. */
   public static final String P_USESYSTEMPROPERTIES = "useSystemProperties";
 
@@ -118,6 +122,7 @@ public class ProxyServlet extends HttpServlet {
   protected int connectTimeout = -1;
   protected int readTimeout = -1;
   protected int connectionRequestTimeout = -1;
+  protected int maxConnections = -1;
 
   //These next 3 are cached here, and should only be referred to in initialization logic. See the
   // ATTR_* parameters.
@@ -191,6 +196,11 @@ public class ProxyServlet extends HttpServlet {
     if (connectionRequestTimeout != null) {
       this.connectionRequestTimeout = Integer.parseInt(connectionRequestTimeout);
     }
+    
+    String maxConnections = getConfigParam(P_MAXCONNECTIONS);
+    if (maxConnections != null) {
+      this.maxConnections = Integer.parseInt(maxConnections);
+    }
 
     String useSystemPropertiesString = getConfigParam(P_USESYSTEMPROPERTIES);
     if (useSystemPropertiesString != null) {
@@ -251,6 +261,9 @@ public class ProxyServlet extends HttpServlet {
     HttpClientBuilder clientBuilder = HttpClientBuilder.create()
                                         .setDefaultRequestConfig(buildRequestConfig())
                                         .setDefaultSocketConfig(buildSocketConfig());
+    
+    clientBuilder.setMaxConnTotal(maxConnections);
+    
     if (useSystemProperties)
       clientBuilder = clientBuilder.useSystemProperties();
     return clientBuilder.build();


### PR DESCRIPTION
The connection and read timeouts are configurable as a init-param in the servlet configuration, but there is not an equivalent property for the connection request timeout (the timeout in milliseconds used when requesting a connection from the connection manager).
