### PR TITLE
Change ProxyServlet.encodeUriQuery to non-static so that it can be overridden

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -693,7 +693,7 @@ public class ProxyServlet extends HttpServlet {
    * @param in example: name=value&amp;foo=bar#fragment
    * @param encodePercent determine whether percent characters need to be encoded
    */
-  protected static CharSequence encodeUriQuery(CharSequence in, boolean encodePercent) {
+  protected CharSequence encodeUriQuery(CharSequence in, boolean encodePercent) {
     //Note that I can't simply use URI.java to encode because it will escape pre-existing escaped things.
     StringBuilder outBuf = null;
     Formatter formatter = null;


### PR DESCRIPTION
I'd like to allow redirects of URL with an encoded slash (%2F).
As mentioned in #34, one way of doing it is to use `getRequestURI` instead of `getPathInfo`.
It'd be great if you could do it in `org.mitre.dsmiley.httpproxy.ProxyServlet`, but would be still nice if its child class like the below example can do it themselves.

```
public class MyProxyServlet extends ProxyServlet {
  /**
   * Get undecoded version of servletRequest.getPathInfo()
   */
  @Override
  protected String rewritePathInfoFromRequest(HttpServletRequest servletRequest) {
    String temp = servletRequest.getContextPath().concat( servletRequest.getServletPath() );
    return servletRequest.getRequestURI().substring( temp.length() );
  }

  // Do not encode here because it is not decoded.
  @Override
  protected CharSequence encodeUriQuery(CharSequence in, boolean encodePercent) {
    return in;
  }
}
```