### PR TITLE
More Extension Points for ProxyServlet

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -31,7 +31,6 @@ import org.apache.http.client.utils.URIUtils;
 import org.apache.http.config.SocketConfig;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicHttpEntityEnclosingRequest;
 import org.apache.http.message.BasicHttpRequest;
@@ -258,7 +257,7 @@ public class ProxyServlet extends HttpServlet {
    * In any case, it should be thread-safe.
    */
   protected HttpClient createHttpClient() {
-    HttpClientBuilder clientBuilder = HttpClientBuilder.create()
+    HttpClientBuilder clientBuilder = getHttpClientBuilder()
                                         .setDefaultRequestConfig(buildRequestConfig())
                                         .setDefaultSocketConfig(buildSocketConfig());
     
@@ -266,7 +265,29 @@ public class ProxyServlet extends HttpServlet {
     
     if (useSystemProperties)
       clientBuilder = clientBuilder.useSystemProperties();
+    return buildHttpClient(clientBuilder);
+  }
+
+  /**
+   * Creates a HttpClient from the given builder. Meant as postprocessor
+   * to possibly adapt the client builder prior to creating the
+   * HttpClient.
+   *
+   * @param clientBuilder pre-configured client builder
+   * @return HttpClient
+   */
+  protected HttpClient buildHttpClient(HttpClientBuilder clientBuilder) {
     return clientBuilder.build();
+  }
+
+  /**
+   * Creates a {@code HttpClientBuilder}. Meant as preprocessor to possibly
+   * adapt the client builder prior to any configuration got applied.
+   *
+   * @return HttpClient builder
+   */
+  protected HttpClientBuilder getHttpClientBuilder() {
+    return HttpClientBuilder.create();
   }
 
   /**
@@ -527,26 +548,56 @@ public class ProxyServlet extends HttpServlet {
    */
   protected void copyProxyCookie(HttpServletRequest servletRequest,
                                  HttpServletResponse servletResponse, String headerValue) {
-    //build path for resulting cookie
-    String path = servletRequest.getContextPath(); // path starts with / or is empty string
-    path += servletRequest.getServletPath(); // servlet path starts with / or is empty string
-    if(path.isEmpty()){
-      path = "/";
-    }
-
     for (HttpCookie cookie : HttpCookie.parse(headerValue)) {
-      //set cookie name prefixed w/ a proxy value so it won't collide w/ other cookies
-      String proxyCookieName = doPreserveCookies ? cookie.getName() : getCookieNamePrefix(cookie.getName()) + cookie.getName();
-      Cookie servletCookie = new Cookie(proxyCookieName, cookie.getValue());
-      servletCookie.setComment(cookie.getComment());
-      servletCookie.setMaxAge((int) cookie.getMaxAge());
-      servletCookie.setPath(path); //set to the path of the proxy servlet
-      // don't set cookie domain
-      servletCookie.setSecure(cookie.getSecure());
-      servletCookie.setVersion(cookie.getVersion());
-      servletCookie.setHttpOnly(cookie.isHttpOnly());
+      Cookie servletCookie = createProxyCookie(servletRequest, cookie);
       servletResponse.addCookie(servletCookie);
     }
+  }
+
+  /**
+   * Creates a proxy cookie from the original cookie.
+   *
+   * @param servletRequest original request
+   * @param cookie original cookie
+   * @return proxy cookie
+   */
+  protected Cookie createProxyCookie(HttpServletRequest servletRequest, HttpCookie cookie) {
+    String proxyCookieName = getProxyCookieName(cookie);
+    Cookie servletCookie = new Cookie(proxyCookieName, cookie.getValue());
+    servletCookie.setPath(buildProxyCookiePath(servletRequest)); //set to the path of the proxy servlet
+    servletCookie.setComment(cookie.getComment());
+    servletCookie.setMaxAge((int) cookie.getMaxAge());
+    // don't set cookie domain
+    servletCookie.setSecure(cookie.getSecure());
+    servletCookie.setVersion(cookie.getVersion());
+    servletCookie.setHttpOnly(cookie.isHttpOnly());
+    return servletCookie;
+  }
+
+  /**
+   * Set cookie name prefixed with a proxy value so it won't collide with other cookies.
+   *
+   * @param cookie cookie to get proxy cookie name for
+   * @return non-conflicting proxy cookie name
+   */
+  protected String getProxyCookieName(HttpCookie cookie) {
+    //
+    return doPreserveCookies ? cookie.getName() : getCookieNamePrefix(cookie.getName()) + cookie.getName();
+  }
+
+  /**
+   * Create path for proxy cookie.
+   *
+   * @param servletRequest original request
+   * @return proxy cookie path
+   */
+  protected String buildProxyCookiePath(HttpServletRequest servletRequest) {
+    String path = servletRequest.getContextPath(); // path starts with / or is empty string
+    path += servletRequest.getServletPath(); // servlet path starts with / or is empty string
+    if (path.isEmpty()) {
+      path = "/";
+    }
+    return path;
   }
 
   /**


### PR DESCRIPTION
In order to have more control for customized ProxyServlets to intervene HttpClient building as well as copying cookies, introduced more extension points.

This will for example help, if you want to create a HTTPS Certificate agnostic HttpClient as in mitre/HTTP-Proxy-Servlet#3.

The extension point for the `HttpClient` is required for adaptions like in mitre/HTTP-Proxy-Servlet#3, i. e. to add a customized SSLSocketFactory.

We required the extension point for copying cookies, in order to customize `servletCookie.setSecure(cookie.getSecure());` which we adjusted to:

```
servletCookie.setSecure("https".equals(servletRequest.getScheme()) && cookie.getSecure());
```
