### PR TITLE
Propagate X-Fordwarded-Proto if present in the request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.mitre.dsmiley.httpproxy</groupId>
   <artifactId>smiley-http-proxy-servlet</artifactId>
-  <version>1.12-SNAPSHOT</version>
+  <version>1.12</version>
   <packaging>jar</packaging>
 
   <name>Smiley's HTTP Proxy Servlet</name>

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -489,6 +489,10 @@ public class ProxyServlet extends HttpServlet {
 
       String protoHeaderName = "X-Forwarded-Proto";
       String protoHeader = servletRequest.getScheme();
+      String existingProtoHeader = servletRequest.getHeader(protoHeaderName);
+      if (existingProtoHeader != null) {
+        protoHeader = existingProtoHeader;
+      }
       proxyRequest.setHeader(protoHeaderName, protoHeader);
     }
   }


### PR DESCRIPTION
Current implementation is not propagating X-Forwarded-Proto when the hedader is present in the proxy servlet request.

If Proxy servlet is behind a https termination element, the original protocol is not forwarded
