### PR TITLE
Add an option to ignore or not the http header "Origin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following is a list of parameters that can be configured
 + log: A boolean parameter name to enable logging of input and target URLs to the servlet log.
 + forwardip: A boolean parameter name to enable forwarding of the client IP
 + preserveHost: A boolean parameter name to keep HOST parameter as-is  
++ preserveOrigin: A boolean parameter name to keep Origin parameter as-is  
 + preserveCookies: A boolean parameter name to keep COOKIES as-is
 + http.protocol.handle-redirects: A boolean parameter name to have auto-handle redirects
 + http.socket.timeout: A integer parameter name to set the socket connection timeout (millis)

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -81,6 +81,9 @@ public class ProxyServlet extends HttpServlet {
   /** A boolean parameter name to keep HOST parameter as-is  */
   public static final String P_PRESERVEHOST = "preserveHost";
 
+  /** A boolean parameter name to keep Origin parameter as-is  */
+  public static final String P_PRESERVEORIGIN = "preserveOrigin";
+
   /** A boolean parameter name to keep COOKIES as-is  */
   public static final String P_PRESERVECOOKIES = "preserveCookies";
 
@@ -109,6 +112,8 @@ public class ProxyServlet extends HttpServlet {
   protected static final String ATTR_TARGET_HOST =
           ProxyServlet.class.getSimpleName() + ".targetHost";
 
+  public static final String ATTR_HTTP_HEADER_ORIGIN = "Origin";
+
   /* MISC */
 
   protected boolean doLog = false;
@@ -116,6 +121,7 @@ public class ProxyServlet extends HttpServlet {
   /** User agents shouldn't send the url fragment but what if it does? */
   protected boolean doSendUrlFragment = true;
   protected boolean doPreserveHost = false;
+  protected boolean doPreserveOrigin = true;
   protected boolean doPreserveCookies = false;
   protected boolean doHandleRedirects = false;
   protected boolean useSystemProperties = true;
@@ -170,6 +176,11 @@ public class ProxyServlet extends HttpServlet {
     String preserveHostString = getConfigParam(P_PRESERVEHOST);
     if (preserveHostString != null) {
       this.doPreserveHost = Boolean.parseBoolean(preserveHostString);
+    }
+
+    String preserveOriginString = getConfigParam(P_PRESERVEORIGIN);
+    if (preserveOriginString != null) {
+      this.doPreserveOrigin = Boolean.parseBoolean(preserveOriginString);
     }
 
     String preserveCookiesString = getConfigParam(P_PRESERVECOOKIES);
@@ -456,6 +467,12 @@ public class ProxyServlet extends HttpServlet {
       return;
     if (hopByHopHeaders.containsHeader(headerName))
       return;
+
+    // In case the target server does not support CORS,
+    // just ignore the "Origin" to make the work done.
+    if(!doPreserveOrigin && ATTR_HTTP_HEADER_ORIGIN.equalsIgnoreCase(headerName)){
+      return;
+    }
 
     @SuppressWarnings("unchecked")
     Enumeration<String> headers = servletRequest.getHeaders(headerName);


### PR DESCRIPTION
Add an parameter to decide whether or not to keep the header "Origin". If the target server does not support CORS(As I have actually met) and the request has an "Origin", a failure will happen.
When ignore the "Origin" item, everything will be just fine.