### PR TITLE
Improved connection handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@ Thanks Mark Michaelis.
 \#176: Flush chunked responses to support Server Sent Events (SSE).
 Thanks Matthias Bläsing
 
+\#181: Ensure the configured maximum number of connections can actually be
+established in a reverse proxy scenario. Ensure proxy connection is shutdown
+when client connection is closed.
+Thanks Matthias Bläsing
+
 # Version 1.11 2019-01-12
 
 \#155: Add OSGI manifiest headers.

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -263,6 +263,7 @@ public class ProxyServlet extends HttpServlet {
                                         .setDefaultSocketConfig(buildSocketConfig());
     
     clientBuilder.setMaxConnTotal(maxConnections);
+    clientBuilder.setMaxConnPerRoute(maxConnections);
     
     if (useSystemProperties)
       clientBuilder = clientBuilder.useSystemProperties();

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -374,7 +374,7 @@ public class ProxyServlet extends HttpServlet {
       }
 
     } catch (Exception e) {
-      handleRequestException(proxyRequest, e);
+      handleRequestException(proxyRequest, proxyResponse, e);
     } finally {
       // make sure the entire entity was consumed, so the connection is released
       if (proxyResponse != null)
@@ -384,11 +384,18 @@ public class ProxyServlet extends HttpServlet {
     }
   }
 
-  protected void handleRequestException(HttpRequest proxyRequest, Exception e) throws ServletException, IOException {
+  protected void handleRequestException(HttpRequest proxyRequest, HttpResponse proxyResonse, Exception e) throws ServletException, IOException {
     //abort request, according to best practice with HttpClient
     if (proxyRequest instanceof AbortableHttpRequest) {
       AbortableHttpRequest abortableHttpRequest = (AbortableHttpRequest) proxyRequest;
       abortableHttpRequest.abort();
+    }
+    // If the response is a chunked response, it is read to completion when
+    // #close is called. If the sending site does not timeout or keeps sending,
+    // the connection will be kept open indefinitely. Closing the respone
+    // object terminates the stream.
+    if (proxyResonse instanceof Closeable) {
+      ((Closeable) proxyResonse).close();
     }
     if (e instanceof RuntimeException)
       throw (RuntimeException)e;
@@ -640,19 +647,16 @@ public class ProxyServlet extends HttpServlet {
       if (entity.isChunked()) {
         // Flush intermediate results before blocking on input -- needed for SSE
         InputStream is = entity.getContent();
-        try {
-          byte[] buffer = new byte[10 * 1024];
-          int read;
-          OutputStream os = servletResponse.getOutputStream();
-          while ((read = is.read(buffer)) != -1) {
-            os.write(buffer, 0, read);
-            if (is.available() == 0) { // next is.read will block
-              os.flush();
-            }
+        OutputStream os = servletResponse.getOutputStream();
+        byte[] buffer = new byte[10 * 1024];
+        int read;
+        while ((read = is.read(buffer)) != -1) {
+          os.write(buffer, 0, read);
+          if (is.available() == 0) { // next is.read will block
+            os.flush();
           }
-        } finally {
-          closeQuietly(is);
         }
+        // Entity closing/cleanup is done in the caller (#service)
       } else {
         OutputStream servletOutputStream = servletResponse.getOutputStream();
         entity.writeTo(servletOutputStream);

--- a/src/test/java/org/mitre/dsmiley/httpproxy/ParallelConnectionsTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ParallelConnectionsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Matthias Bläsing.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mitre.dsmiley.httpproxy;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ParallelConnectionsTest {
+
+  private Server server;
+  private ServletHandler servletHandler;
+  private int serverPort;
+
+  @Before
+  public void setUp() throws Exception {
+    server = new Server(0);
+    servletHandler = new ServletHandler();
+    server.setHandler(servletHandler);
+    server.start();
+
+    serverPort = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.stop();
+    serverPort = -1;
+  }
+
+  @Test
+  public void testHandlingMultipleConnectionsSameRoute() throws Exception {
+    /*
+     This test ensures, that a minimum nunmber of parallel connections can be
+     established. The test works by opening "parallelConnectionsToTest"
+     connections, this is enforced by a countdownlatch, that ensures, that all
+     connections to the backend are established before they are served by the
+     demo servlet.
+     */
+
+    int parallelConnectionsToTest = 10;
+
+    ServletHolder servletHolder = servletHandler.addServletWithMapping(ProxyServlet.class, "/sampleBackendProxied/*");
+    servletHolder.setInitParameter(ProxyServlet.P_LOG, "true");
+    servletHolder.setInitParameter(ProxyServlet.P_MAXCONNECTIONS, Integer.toString(parallelConnectionsToTest));
+    servletHolder.setInitParameter(ProxyServlet.P_TARGET_URI, String.format("http://localhost:%d/sampleBackend/", serverPort));
+
+    CountDownLatch requestsReceived = new CountDownLatch(parallelConnectionsToTest);
+
+    ServletHolder dummyBackend = new ServletHolder(new HttpServlet() {
+      @Override
+      protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+          // The latch ensures, that all servlets wait until all expected
+          // connections are made. Only after all clients have connected, the
+          // request is fullfilled.
+          requestsReceived.countDown();
+          if (requestsReceived.await(10, TimeUnit.SECONDS)) {
+            resp.setHeader("Content-Type", "text/plain; charset=utf-8");
+            OutputStream os = resp.getOutputStream();
+            OutputStreamWriter osw = new OutputStreamWriter(os, StandardCharsets.UTF_8);
+            osw.write("Works");
+            osw.flush();
+          }
+        } catch (InterruptedException ex) {
+          throw new IOException(ex);
+        }
+      }
+    });
+    servletHandler.addServletWithMapping(dummyBackend, "/sampleBackend/*");
+
+    URL url = new URL(String.format("http://localhost:%d/sampleBackendProxied/test", serverPort));
+
+    ExecutorService es = Executors.newFixedThreadPool(parallelConnectionsToTest);
+
+    class Client implements Callable<String> {
+      @Override
+      public String call() throws Exception {
+        try (InputStream is = url.openStream();
+                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+          byte[] buffer = new byte[10 * 1024];
+          int read;
+          while((read = is.read(buffer)) > 0) {
+            baos.write(buffer, 0, read);
+          }
+          return baos.toString("UTF-8");
+        }
+      }
+    }
+
+    List<Future<String>> result = new ArrayList<>(parallelConnectionsToTest);
+
+    for(int i = 0; i < parallelConnectionsToTest; i++) {
+      result.add(es.submit(new Client()));
+    }
+
+    for(Future<String> f: result) {
+      assertEquals("Works", f.get());
+    }
+  }
+}


### PR DESCRIPTION
When working with server send events I noticed, that connection issues were observed in the production environment. Two issues could be identified, that combine:

- apache http client limits the number of connections per route to 2 - as that value is never overwritten, this is the effective upper limit for parallel reverse proxy connections
- a connection, that is closed in the frontend does not cause the backing connection to be closed

Both conditions might have been problems already in the past, but they are less likely to be observed if only short lived http connections (small transfers, non-persistent connections).