### PR TITLE
Casting `char` to `int` is redundant

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -806,7 +806,7 @@ public class ProxyServlet extends HttpServlet {
       char c = in.charAt(i);
       boolean escape = true;
       if (c < 128) {
-        if (asciiQueryChars.get((int)c) && !(encodePercent && c == '%')) {
+        if (asciiQueryChars.get(c) && !(encodePercent && c == '%')) {
           escape = false;
         }
       } else if (!Character.isISOControl(c) && !Character.isSpaceChar(c)) {//not-ascii
@@ -836,14 +836,14 @@ public class ProxyServlet extends HttpServlet {
     char[] c_reserved = "/[]@".toCharArray();//plus punct.  Exclude '?'; RFC-2616 3.2.2
 
     asciiQueryChars = new BitSet(128);
-    for(char c = 'a'; c <= 'z'; c++) asciiQueryChars.set((int)c);
-    for(char c = 'A'; c <= 'Z'; c++) asciiQueryChars.set((int)c);
-    for(char c = '0'; c <= '9'; c++) asciiQueryChars.set((int)c);
-    for(char c : c_unreserved) asciiQueryChars.set((int)c);
-    for(char c : c_punct) asciiQueryChars.set((int)c);
-    for(char c : c_reserved) asciiQueryChars.set((int)c);
+    for(char c = 'a'; c <= 'z'; c++) asciiQueryChars.set(c);
+    for(char c = 'A'; c <= 'Z'; c++) asciiQueryChars.set(c);
+    for(char c = '0'; c <= '9'; c++) asciiQueryChars.set(c);
+    for(char c : c_unreserved) asciiQueryChars.set(c);
+    for(char c : c_punct) asciiQueryChars.set(c);
+    for(char c : c_reserved) asciiQueryChars.set(c);
 
-    asciiQueryChars.set((int)'%');//leave existing percent escapes in place
+    asciiQueryChars.set('%');//leave existing percent escapes in place
   }
 
 }


### PR DESCRIPTION
As reported by IntelliJ.