### PR TITLE
Fixed Secure Cookie issue where the Proxy is accessible via HTTP.

### DIFF
--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -594,7 +594,7 @@ public class ProxyServlet extends HttpServlet {
     servletCookie.setComment(cookie.getComment());
     servletCookie.setMaxAge((int) cookie.getMaxAge());
     // don't set cookie domain
-    servletCookie.setSecure(cookie.getSecure());
+    servletCookie.setSecure(servletRequest.isSecure() && cookie.getSecure());
     servletCookie.setVersion(cookie.getVersion());
     servletCookie.setHttpOnly(cookie.isHttpOnly());
     return servletCookie;


### PR DESCRIPTION
I've recently encountered a situation where the proxy servlet was exposed on HTTP but where the external service was HTTPS. This all worked fine until that external service started returning cookies with the secure flag set. As it stands, the proxy servlet just copies this attribute but, in this scenario, to stop the cookies getting thrown away, the secure flag needs to be disabled. This is, of course, only applies where the servlet request is not accessed securely.

Note that there's no unit test for this as HttpUnit doesn't pass on the Secure attribute of Cookies.