### PR TITLE
preserveCookiePath configuration parameter support added.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Version 1.13 (unreleased)
 
-_(no changes)_
+\#231: Added support of preserveCookiePath configuration parameter. It allows to keep cookie path unchanged in Set-Cookie server response header.
 
 # Version 1.12.1 released on 2021-12-28
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following is a list of parameters that can be configured
 + forwardip: A boolean parameter name to enable forwarding of the client IP
 + preserveHost: A boolean parameter name to keep HOST parameter as-is  
 + preserveCookies: A boolean parameter name to keep COOKIES as-is
++ preserveCookiePath: A boolean parameter name to keep cookie path unchanged in Set-Cookie server response header
 + http.protocol.handle-redirects: A boolean parameter name to have auto-handle redirects
 + http.socket.timeout: A integer parameter name to set the socket connection timeout (millis)
 + http.read.timeout: A integer parameter name to set the socket read timeout (millis)

--- a/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/src/main/java/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -84,6 +84,9 @@ public class ProxyServlet extends HttpServlet {
   /** A boolean parameter name to keep COOKIES as-is  */
   public static final String P_PRESERVECOOKIES = "preserveCookies";
 
+  /** A boolean parameter name to keep COOKIE path as-is  */
+  public static final String P_PRESERVECOOKIEPATH = "preserveCookiePath";
+
   /** A boolean parameter name to have auto-handle redirects */
   public static final String P_HANDLEREDIRECTS = "http.protocol.handle-redirects"; // ClientPNames.HANDLE_REDIRECTS
 
@@ -121,6 +124,7 @@ public class ProxyServlet extends HttpServlet {
   protected boolean doSendUrlFragment = true;
   protected boolean doPreserveHost = false;
   protected boolean doPreserveCookies = false;
+  protected boolean doPreserveCookiePath = false;
   protected boolean doHandleRedirects = false;
   protected boolean useSystemProperties = true;
   protected boolean doHandleCompression = false;
@@ -180,6 +184,11 @@ public class ProxyServlet extends HttpServlet {
     String preserveCookiesString = getConfigParam(P_PRESERVECOOKIES);
     if (preserveCookiesString != null) {
       this.doPreserveCookies = Boolean.parseBoolean(preserveCookiesString);
+    }
+
+    String preserveCookiePathString = getConfigParam(P_PRESERVECOOKIEPATH);
+    if (preserveCookiePathString != null) {
+      this.doPreserveCookiePath = Boolean.parseBoolean(preserveCookiePathString);
     }
 
     String handleRedirectsString = getConfigParam(P_HANDLEREDIRECTS);
@@ -590,7 +599,10 @@ public class ProxyServlet extends HttpServlet {
   protected Cookie createProxyCookie(HttpServletRequest servletRequest, HttpCookie cookie) {
     String proxyCookieName = getProxyCookieName(cookie);
     Cookie servletCookie = new Cookie(proxyCookieName, cookie.getValue());
-    servletCookie.setPath(buildProxyCookiePath(servletRequest)); //set to the path of the proxy servlet
+    servletCookie.setPath(this.doPreserveCookiePath ?
+       cookie.getPath() : // preserve original cookie path
+       buildProxyCookiePath(servletRequest) //set to the path of the proxy servlet
+    );
     servletCookie.setComment(cookie.getComment());
     servletCookie.setMaxAge((int) cookie.getMaxAge());
     // don't set cookie domain


### PR DESCRIPTION
I have implemented the preserveCookiePath additional configuration parameter.
It allows the service under the proxy to seamlessly become a part of main site.
In practice I used it to share authentication cookie between distinct  parts of heterogeneous (Java + PHP) system.