### PR TITLE
Allow multiple request parameters with the same key

### DIFF
--- a/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletTest.java
@@ -129,7 +129,8 @@ public class ProxyServletTest
           "/p?query=note%3ALeitbild",
           "/p?id=p%20i", "/p%20i", // encoded space in param then in path
           "/p?id=p+i",
-          "/pathwithquestionmark%3F%3F?from=1&to=10" // encoded question marks
+          "/pathwithquestionmark%3F%3F?from=1&to=10", // encoded question marks
+          "/multipleparamssamekey?duplicatedParam=value1&duplicatedParam=value&p3=v3" // multiple parameters with the same name
   };
   //TODO add "/p//doubleslash//f.txt" however HTTPUnit gets in the way. See issue #24
 


### PR DESCRIPTION
Before this change when a user sends multiple request parameters with the same key, for example `/myproxy?param1=value1&param1=value2`, the proxy only sent the last value to the target server, `?param1=value2`.
With this change it sends both entries, `?param1=value1&param1=value2`.
