### PR TITLE
Adding jakarta servlet API 6 compatibility

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,26 +9,26 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-       include:
-         - HTTPCLIENT_VERSION: 4.5.13
-           HTTPCLIENT_TEST_VERSION: 4.3.6
-           JAKARTA_VERSION: [5.0.0, 6.0.0]
-           JDOC: "site"           
-           
+        JAKARTA_VERSION: [5.0.0, 6.0.0]
+        include:
+          - HTTPCLIENT_VERSION: 4.5.13
+            HTTPCLIENT_TEST_VERSION: 4.3.6
+            JDOC: "site"
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11     
-    - name: Build with Maven
-      env:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        env:
           HTTPCLIENT_VERSION: ${{ matrix.HTTPCLIENT_VERSION }}
           HTTPCLIENT_TEST_VERSION: ${{ matrix.HTTPCLIENT_TEST_VERSION }}
           JAKARTA_VERSION: ${{ matrix.JAKARTA_VERSION }}
           JDOC: ${{ matrix.JDOC }}
-      run: mvn -B -Dhttpclient.version=$HTTPCLIENT_VERSION -Dhttpclient.test.version=$HTTPCLIENT_TEST_VERSION -Djakarta.version=$JAKARTA_VERSION verify $JDOC
-        
+        run: mvn -B -Dhttpclient.version=$HTTPCLIENT_VERSION -Dhttpclient.test.version=$HTTPCLIENT_TEST_VERSION -Djakarta.version=$JAKARTA_VERSION verify $JDOC
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,6 +15,7 @@ jobs:
        include:
          - HTTPCLIENT_VERSION: 4.5.13
            HTTPCLIENT_TEST_VERSION: 4.3.6
+           JAKARTA_VERSION: [5.0.0, 6.0.0]
            JDOC: "site"           
            
     steps:
@@ -27,6 +28,7 @@ jobs:
       env:
           HTTPCLIENT_VERSION: ${{ matrix.HTTPCLIENT_VERSION }}
           HTTPCLIENT_TEST_VERSION: ${{ matrix.HTTPCLIENT_TEST_VERSION }}
+          JAKARTA_VERSION: ${{ matrix.JAKARTA_VERSION }}
           JDOC: ${{ matrix.JDOC }}
-      run: mvn -B -Dhttpclient.version=$HTTPCLIENT_VERSION -Dhttpclient.test.version=$HTTPCLIENT_TEST_VERSION verify $JDOC
+      run: mvn -B -Dhttpclient.version=$HTTPCLIENT_VERSION -Dhttpclient.test.version=$HTTPCLIENT_TEST_VERSION -Djakarta.version=$JAKARTA_VERSION verify $JDOC
         

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.mitre.dsmiley.httpproxy</groupId>
   <artifactId>smiley-http-proxy-servlet</artifactId>
-  <version>3.0-SNAPSHOT</version>
+  <version>2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Smiley's HTTP Proxy Servlet</name>
@@ -41,6 +41,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <!-- should work with the following versions of jakarta -->
+    <jakarta.version>[5.0.0, 6.0.0]</jakarta.version>
     <!-- works with v4.3 and forward; see .github/workflows/maven.yml -->
     <httpclient.version>[4.5.14,5.0)</httpclient.version>
     <!-- the last version to provide LocalTestServer.java -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.mitre.dsmiley.httpproxy</groupId>
   <artifactId>smiley-http-proxy-servlet</artifactId>
-  <version>2.1-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Smiley's HTTP Proxy Servlet</name>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>5.0.0</version>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
I am trying to use the proxy with jetty 12 ee10, which uses jakarta 6. This change and version bump uses v6
 (context https://en.wikipedia.org/wiki/Jakarta_EE).

All tests pass and package is generated

```
➜  HTTP-Proxy-Servlet : master ✘ :✹ ᐅ  mvn clean compile test package
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  30.635 s
[INFO] Finished at: 2024-04-19T16:48:47+01:00
[INFO] ------------------------------------------------------------------------
```