### PR TITLE
Allow proxying requests through an outgoing HTTP proxy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,19 @@
       <version>11.0.15</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.littleshoot</groupId>
+      <artifactId>littleproxy</artifactId>
+      <version>1.1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jcl</artifactId>
+      <version>1.7.36</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletThroughHttpProxyTest.java
+++ b/src/test/java/org/mitre/dsmiley/httpproxy/ProxyServletThroughHttpProxyTest.java
@@ -1,0 +1,30 @@
+package org.mitre.dsmiley.httpproxy;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import java.util.Properties;
+
+public class ProxyServletThroughHttpProxyTest extends ProxyServletTest {
+
+    private static HttpProxyServer proxyServer;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        proxyServer = DefaultHttpProxyServer.bootstrap().start();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        proxyServer.stop();
+    }
+
+    @Override
+    protected void setUpServlet(Properties servletProps) {
+        servletProps.setProperty(ProxyServlet.P_HTTP_PROXY_HOST_AND_PORT, "localhost:" + proxyServer.getListenAddress().getPort());
+        super.setUpServlet(servletProps);
+    }
+
+}


### PR DESCRIPTION
Added the ability to proxy requests through an outgoing HTTP proxy.

An outgoing HTTP proxy can now be supplied in the format _HOST:PORT_ through the servlet init parameter `http.proxy.host-and-port`. In that case, the underlying `HttpClient` will use a route planner that always goes through that proxy.